### PR TITLE
fix: video feed playback compatibility + upload failure handling

### DIFF
--- a/components/Modals/VideoUploadModal.tsx
+++ b/components/Modals/VideoUploadModal.tsx
@@ -5,6 +5,7 @@ import {
   Dimensions,
   Animated,
   Alert,
+  Platform,
 } from "react-native";
 import styled from "styled-components/native";
 import { Ionicons } from "@expo/vector-icons";
@@ -37,6 +38,9 @@ interface VideoUploadModalProps {
 const PROCESSING_MESSAGES = [
   "Processing — this may take a couple of minutes",
   "Please do not close this modal",
+  ...(Platform.OS === "ios"
+    ? ["Videos stored in iCloud may take longer to load - "]
+    : []),
   "Preparing your video for upload",
   "Analysing video quality...",
   "Getting your video ready for the feed",

--- a/functions/src/transcodeVideo.ts
+++ b/functions/src/transcodeVideo.ts
@@ -127,16 +127,25 @@ export const transcodeVideo = onRequest(
       const thumbnailUrl = `${R2_PUBLIC_URL.value()}/${thumbnailKey}`;
       console.log("[transcodeVideo] Thumbnail uploaded:", thumbnailUrl);
 
-      // ── 5. Compress video — original resolution and orientation preserved ──
+      // ── 5. Compress video — max compatibility, min size ───────────────────
       console.log("[transcodeVideo] Compressing video...");
       await new Promise<void>((resolve, reject) => {
         ffmpeg(rawTmpPath)
           .outputOptions([
             "-c:v libx264",
-            "-crf 23",
-            "-preset fast",
+            "-profile:v baseline",
+            "-level:v 3.0",
+            "-preset slow",
+            "-crf 28",
+            "-vf scale='min(1280,iw)':-2",
+            "-r 30",
+            "-pix_fmt yuv420p",
+            "-maxrate 1500k",
+            "-bufsize 3000k",
             "-c:a aac",
-            "-b:a 128k",
+            "-b:a 96k",
+            "-ac 2",
+            "-ar 44100",
             "-movflags +faststart",
           ])
           .output(transcodedTmpPath)

--- a/functions/src/videoFunctions.ts
+++ b/functions/src/videoFunctions.ts
@@ -104,7 +104,9 @@ export const generateR2UploadUrl = functions.https.onCall(
       ContentType: fileType || "video/mp4",
     });
 
-    const uploadUrl = await getSignedUrl(r2Client, command, { expiresIn: 900 });
+    const uploadUrl = await getSignedUrl(r2Client, command, {
+      expiresIn: 3600,
+    });
     const publicUrl = `${R2_PUBLIC_URL.value()}/${key}`;
 
     return { uploadUrl, publicUrl, key };

--- a/helpers/recoverPendingVideoUploads.ts
+++ b/helpers/recoverPendingVideoUploads.ts
@@ -3,6 +3,8 @@ import {
   collection,
   getDocs,
   deleteDoc,
+  setDoc,
+  doc,
   query,
   where,
 } from "firebase/firestore";
@@ -18,6 +20,8 @@ type CheckR2VideoParams = {
 type CheckR2VideoResponse = {
   videoUrl: string | null;
 };
+
+const ABANDON_AFTER_MS = 60 * 60 * 1000; // 1 hour of no activity
 
 // Call once in AppContent useEffect when currentUser is available
 export const recoverPendingVideoUploads = async (userId: string) => {
@@ -53,12 +57,16 @@ export const recoverPendingVideoUploads = async (userId: string) => {
       date,
       postedBy,
       teams,
+      progress,
+      platform,
+      startedAt,
     } = docSnap.data();
 
     try {
       const { data } = await checkR2VideoExists({ gameId, competitionId });
 
       if (data.videoUrl) {
+        // ── File made it to R2 — finish the job the killed app didn't ────────
         await updateGameVideoUrl({
           gameId,
           competitionId,
@@ -71,8 +79,38 @@ export const recoverPendingVideoUploads = async (userId: string) => {
           teams,
         });
         await deleteDoc(docSnap.ref);
+        continue;
       }
-      // No file found means upload is still in progress — leave the record intact
+
+      // ── No file in R2 — decide: still uploading, or dead? ──────────────────
+      const startedMs =
+        startedAt?.toMillis?.() ??
+        (startedAt?.seconds ? startedAt.seconds * 1000 : null);
+
+      const isAbandoned =
+        startedMs !== null && Date.now() - startedMs > ABANDON_AFTER_MS;
+
+      if (isAbandoned) {
+        // Older than 1 hour with no file — treat as dead (app killed mid-upload).
+        // Record for diagnostics, then remove so no phantom toast remains.
+        const failedDocRef = doc(
+          db,
+          COLLECTION_NAMES.failedVideoUploads,
+          `${gameId}_${Date.now()}`,
+        );
+        await setDoc(failedDocRef, {
+          gameId,
+          competitionId,
+          userId: postedBy?.userId ?? userId,
+          errorMessage: "abandoned — app killed mid-upload (no activity 1h+)",
+          lastProgress: progress ?? 0,
+          platform: platform ?? "unknown",
+          failedAt: new Date(),
+        });
+        await deleteDoc(docSnap.ref);
+      }
+      // Younger than 1 hour with no file — genuinely may still be uploading.
+      // Leave the record intact.
     } catch (error) {
       console.error(`Failed to recover upload for game ${gameId}:`, error);
     }

--- a/hooks/useVideoUpload.ts
+++ b/hooks/useVideoUpload.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from "react";
 import * as ImagePicker from "expo-image-picker";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 import { getFunctions, httpsCallable } from "firebase/functions";
 import {
   getFirestore,
@@ -68,7 +68,7 @@ export const useVideoUpload = ({
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ["videos"],
       allowsEditing: false,
-      quality: 1,
+      videoExportPreset: ImagePicker.VideoExportPreset.Passthrough,
     });
 
     if (!result.canceled && result.assets[0]) {
@@ -102,6 +102,29 @@ export const useVideoUpload = ({
         gameId,
       );
 
+      // ── Helper: record a failed upload for diagnostics ──────────────────────
+      const recordFailure = async (errorMessage: string, progress: number) => {
+        try {
+          const failedDocRef = doc(
+            db,
+            COLLECTION_NAMES.failedVideoUploads,
+            `${gameId}_${Date.now()}`,
+          );
+          await setDoc(failedDocRef, {
+            gameId,
+            competitionId,
+            userId: postedBy.userId,
+            errorMessage: errorMessage || "unknown",
+            lastProgress: progress,
+            platform: Platform.OS,
+            failedAt: new Date(),
+          });
+          await deleteDoc(pendingDocRef);
+        } catch {
+          // Non-critical — diagnostics/cleanup are best-effort
+        }
+      };
+
       try {
         await setDoc(pendingDocRef, {
           gameId,
@@ -114,6 +137,7 @@ export const useVideoUpload = ({
           teams,
           status: "uploading",
           progress: 0,
+          platform: Platform.OS,
           startedAt: new Date(),
         });
         console.log("[VideoUpload] Pending record written:", gameId);
@@ -124,6 +148,9 @@ export const useVideoUpload = ({
 
       const run = async () => {
         console.log("[VideoUpload] run() started:", { gameId, competitionId });
+
+        let lastReportedProgress = 0;
+
         try {
           const functions = getFunctions();
 
@@ -137,8 +164,6 @@ export const useVideoUpload = ({
             gameId,
             fileType: "video/mp4",
           });
-
-          let lastReportedProgress = 0;
 
           const uploadId = await Upload.startUpload({
             url: data.uploadUrl,
@@ -214,6 +239,10 @@ export const useVideoUpload = ({
                 "[VideoUpload] Upload returned non-2xx status:",
                 completedData.responseCode,
               );
+              await recordFailure(
+                `non-2xx: ${completedData.responseCode}`,
+                lastReportedProgress,
+              );
               showBottomToast(
                 "Video upload failed. Please try again.",
                 "error",
@@ -222,8 +251,12 @@ export const useVideoUpload = ({
           });
 
           // ── Error ─────────────────────────────────────────────────────────
-          Upload.addListener("error", uploadId, (errorData) => {
+          Upload.addListener("error", uploadId, async (errorData) => {
             console.error("[VideoUpload] Upload error:", errorData.error);
+            await recordFailure(
+              errorData.error ?? "unknown",
+              lastReportedProgress,
+            );
             showBottomToast("Video upload failed. Please try again.", "error");
           });
 
@@ -234,6 +267,10 @@ export const useVideoUpload = ({
           });
         } catch (error) {
           console.error("[VideoUpload] Background upload failed:", error);
+          await recordFailure(
+            error instanceof Error ? error.message : "setup failed",
+            lastReportedProgress,
+          );
           showBottomToast("Video upload failed. Please try again.", "error");
         }
       };

--- a/screens/Home/Home.tsx
+++ b/screens/Home/Home.tsx
@@ -55,7 +55,7 @@ import { useGameVideoFeed } from "@/hooks/useGameVideoFeed";
 import { useLikeVideo } from "@/hooks/useLikeVideo";
 import { useFocusEffect } from "@react-navigation/native";
 import ActionPlaceholder from "@/components/ActionPlaceholder";
-import { addPlayerToCompetition } from "@/devFunctions/addPlayerToCompetition";
+// import { addPlayerToCompetition } from "@/devFunctions/addPlayerToCompetition";
 // ─── Video Feed Config ────────────────────────────────────────────────────────
 
 const VIEWABILITY_CONFIG: ViewabilityConfig = {
@@ -238,7 +238,7 @@ const Home = () => {
           </SocialRow>
         </Overview>
 
-        <TouchableOpacity
+        {/* <TouchableOpacity
           onPress={() =>
             addPlayerToCompetition({
               userId: "VXk56Lk6eITWa5aEuysyBfEVjXo2",
@@ -249,7 +249,7 @@ const Home = () => {
           }
         >
           <Text style={{ color: "white" }}>Add Player</Text>
-        </TouchableOpacity>
+        </TouchableOpacity> */}
 
         {currentUser ? (
           <Text style={{ color: "white", marginVertical: 10 }}>

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -38,6 +38,7 @@ export const COLLECTION_NAMES: Record<CollectionName, string> = {
   reportedVideos: "reportedVideos",
   savedVideos: "savedVideos",
   videoReportAppeals: "videoReportAppeals",
+  failedVideoUploads: "failedVideoUploads",
 };
 
 export const ICON_MAP = {

--- a/shared/types/competition.ts
+++ b/shared/types/competition.ts
@@ -11,7 +11,8 @@ export type CollectionName =
   | "replies"
   | "reportedVideos"
   | "savedVideos"
-  | "videoReportAppeals";
+  | "videoReportAppeals"
+  | "failedVideoUploads";
 
 export type CompetitionType =
   | typeof COMPETITION_TYPES.LEAGUE


### PR DESCRIPTION
 Backend (transcodeVideo):
- Force 8-bit yuv420p, Constrained Baseline, level 3.0, 30fps for
  universal device playback (fixes black video on Android/simulators
  caused by 10-bit High-profile source files)
- Cap resolution at 1280w with even dimensions, add bitrate ceiling
  (-maxrate 1500k) and faststart for reliable streaming
- Raise generateR2UploadUrl presigned URL expiry 900s -> 3600s so large
  Passthrough originals don't expire mid-upload

Frontend (useVideoUpload):
- Keep Passthrough export preset (skips on-device re-encode, fixes
  long-video picker hang; server handles compression)
- Record all upload failures to failedVideoUploads (error message, last
  progress, platform) and clean up pending docs on every failure path

Recovery (recoverPendingVideoUploads):
- Sweep pending uploads with no R2 file and no activity for 1h+ into
  failedVideoUploads as abandoned (app killed mid-upload), preventing
  phantom upload toasts
