### PR TITLE
Fix deprecated getInfoAsync in image pickers

### DIFF
--- a/screens/Home/Leagues/EditLeague.js
+++ b/screens/Home/Leagues/EditLeague.js
@@ -18,7 +18,7 @@ import { uploadLeagueImage } from "../../../utils/UploadLeagueImageToFirebase";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import Popup from "../../../components/popup/Popup";
 import { PopupContext } from "../../../context/PopupContext";
-import * as FileSystem from "expo-file-system";
+import { File } from "expo-file-system";
 import { COLLECTION_NAMES } from "@shared";
 
 const EditLeague = () => {
@@ -101,7 +101,7 @@ const EditLeague = () => {
         const MAX_SIZE = 5 * 1024 * 1024; // 5MB in bytes
 
         // Get file info to check size
-        const fileInfo = await FileSystem.getInfoAsync(pickedUri);
+        const fileInfo = new File(pickedUri);
 
         if (fileInfo.size && fileInfo.size > MAX_SIZE) {
           Alert.alert(
@@ -121,7 +121,7 @@ const EditLeague = () => {
         );
 
         // Optional: Log the final image size
-        const croppedInfo = await FileSystem.getInfoAsync(cropped.uri);
+        const croppedInfo = new File(cropped.uri);
         console.log(
           `Final image size: ${(croppedInfo.size / 1024).toFixed(1)}KB`,
         );

--- a/screens/Home/Tournaments/EditTournament.js
+++ b/screens/Home/Tournaments/EditTournament.js
@@ -18,7 +18,7 @@ import { uploadLeagueImage } from "../../../utils/UploadLeagueImageToFirebase";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import Popup from "../../../components/popup/Popup";
 import { PopupContext } from "../../../context/PopupContext";
-import * as FileSystem from "expo-file-system";
+import { File } from "expo-file-system";
 import { COLLECTION_NAMES } from "@shared";
 
 const EditTournament = () => {
@@ -101,7 +101,7 @@ const EditTournament = () => {
         const MAX_SIZE = 5 * 1024 * 1024; // 5MB in bytes
 
         // Get file info to check size
-        const fileInfo = await FileSystem.getInfoAsync(pickedUri);
+        const fileInfo = new File(pickedUri);
 
         if (fileInfo.size && fileInfo.size > MAX_SIZE) {
           Alert.alert(
@@ -121,7 +121,7 @@ const EditTournament = () => {
         );
 
         // Optional: Log the final image size
-        const croppedInfo = await FileSystem.getInfoAsync(cropped.uri);
+        const croppedInfo = new File(cropped.uri);
         console.log(
           `Final image size: ${(croppedInfo.size / 1024).toFixed(1)}KB`,
         );

--- a/screens/Profile/EditProfile.js
+++ b/screens/Profile/EditProfile.js
@@ -20,7 +20,7 @@ import { loadCountries, loadCities } from "../../utils/locationData";
 import ListDropdown from "../../components/ListDropdown/ListDropdown";
 import { PopupContext } from "../../context/PopupContext";
 import Popup from "../../components/popup/Popup";
-import * as FileSystem from "expo-file-system";
+import { File } from "expo-file-system";
 
 const EditProfile = ({ navigation }) => {
   const { currentUser, updateUserProfile } = useContext(UserContext);
@@ -145,7 +145,7 @@ const EditProfile = ({ navigation }) => {
         const MAX_SIZE = 5 * 1024 * 1024; // 5MB in bytes
 
         // Get file info to check size
-        const fileInfo = await FileSystem.getInfoAsync(pickedUri);
+        const fileInfo = new File(pickedUri);
 
         if (fileInfo.size && fileInfo.size > MAX_SIZE) {
           Alert.alert(
@@ -165,7 +165,7 @@ const EditProfile = ({ navigation }) => {
         );
 
         // Optional: Double-check the manipulated image size
-        const manipulatedInfo = await FileSystem.getInfoAsync(manipulated.uri);
+        const manipulatedInfo = new File(manipulated.uri);
         console.log(
           `Final image size: ${(manipulatedInfo.size / 1024).toFixed(1)}KB`,
         );


### PR DESCRIPTION
Migrate the image size checks in EditLeague, EditTournament and EditProfile from the deprecated expo-file-system getInfoAsync to the new File class API, matching the pattern already used in VideoUploadModal. This resolves the 'Image picker error' thrown when selecting an image on those screens.


Claude-Session: https://claude.ai/code/session_01HFuq4GqiGzvVYagGC7JK2Z