### PR TITLE
Fix CourtPositionModal to start with empty positions

### DIFF
--- a/components/Modals/CourtPositionModal.tsx
+++ b/components/Modals/CourtPositionModal.tsx
@@ -41,21 +41,27 @@ const buildInitialPositions = ({
   const slotsPerTeam = isDoubles ? 2 : 1;
   const existing = video.courtPositions;
 
-  const fill = (
-    teamKey: TeamKey,
-    team: { player1: Player; player2?: Player },
-  ) =>
-    Array.from({ length: slotsPerTeam }, (_, index) => {
-      const saved = existing?.[teamKey]?.[index];
-      if (saved !== undefined) return saved;
-      return index === 0 ? (team.player1 ?? null) : (team.player2 ?? null);
-    });
+  // Slots start empty. Only saved positions are restored — nothing is
+  // auto-assigned from the team roster, so the uploader sets them manually.
+  const fill = (teamKey: TeamKey) =>
+    Array.from(
+      { length: slotsPerTeam },
+      (_, index) => existing?.[teamKey]?.[index] ?? null,
+    );
 
   return {
-    team1: fill("team1", video.teams.team1),
-    team2: fill("team2", video.teams.team2),
+    team1: fill("team1"),
+    team2: fill("team2"),
   };
 };
+
+const hasAssignedPositions = (positions?: SelectedPlayers): boolean =>
+  Boolean(
+    positions &&
+      [...positions.team1, ...positions.team2].some(
+        (player) => player != null,
+      ),
+  );
 
 const arePositionsEqual = (a: SelectedPlayers, b: SelectedPlayers): boolean => {
   const sameTeam = (left: (Player | null)[], right: (Player | null)[]) =>
@@ -176,6 +182,12 @@ const CourtPositionsModal = memo<CourtPositionsModalProps>(
               {isUploader
                 ? "Tap a position to set which side each player started on. This helps viewers recognize each player."
                 : "Where each player started on the court."}
+              {!isUploader && !hasAssignedPositions(positions) && (
+                <UnassignedNote>
+                  {" "}
+                  (Uploader has not assigned court positions yet)
+                </UnassignedNote>
+              )}
             </ModalDescription>
 
             <CourtWrapper>
@@ -272,6 +284,12 @@ const ModalDescription = styled.Text({
   paddingVertical: 12,
   //   textAlign: "center",
   //   marginBottom: 12,
+});
+
+const UnassignedNote = styled.Text({
+  color: "#aaa",
+  fontSize: 14,
+  fontStyle: "italic",
 });
 
 // ── Header

--- a/components/Modals/CourtPositionModal.tsx
+++ b/components/Modals/CourtPositionModal.tsx
@@ -41,8 +41,6 @@ const buildInitialPositions = ({
   const slotsPerTeam = isDoubles ? 2 : 1;
   const existing = video.courtPositions;
 
-  // Slots start empty. Only saved positions are restored — nothing is
-  // auto-assigned from the team roster, so the uploader sets them manually.
   const fill = (teamKey: TeamKey) =>
     Array.from(
       { length: slotsPerTeam },
@@ -58,9 +56,7 @@ const buildInitialPositions = ({
 const hasAssignedPositions = (positions?: SelectedPlayers): boolean =>
   Boolean(
     positions &&
-      [...positions.team1, ...positions.team2].some(
-        (player) => player != null,
-      ),
+    [...positions.team1, ...positions.team2].some((player) => player != null),
   );
 
 const arePositionsEqual = (a: SelectedPlayers, b: SelectedPlayers): boolean => {


### PR DESCRIPTION
Court position slots were being auto-filled from the team roster on open, so viewers saw positions the uploader never actually set. Slots now start empty and only restore previously saved positions.

Non-uploaders now see an italic '(Uploader has not assigned court positions yet)' note alongside the description when no positions have been assigned.


Claude-Session: https://claude.ai/code/session_01CSxRvzBfSrfxAL8eZ9s6Fz