### PR TITLE
Replace location ListDropdown with CountryCitySelectionModal flow

### DIFF
--- a/components/Modals/AddClubModal.tsx
+++ b/components/Modals/AddClubModal.tsx
@@ -13,9 +13,7 @@ import {
   KeyboardAvoidingView,
   ActivityIndicator,
   Alert,
-  StyleSheet,
   ScrollView,
-  InteractionManager,
 } from "react-native";
 import * as FileSystem from "expo-file-system";
 import { BlurView } from "expo-blur";
@@ -36,15 +34,13 @@ import { LeagueContext } from "../../context/LeagueContext";
 import { UserContext } from "../../context/UserContext";
 import { generateClubId } from "../../helpers/generateClubId";
 import { uploadClubImage } from "../../utils/UploadClubImageToFirebase";
-import { loadCountries, loadCities } from "../../utils/locationData";
-import ListDropdown from "../ListDropdown/ListDropdown";
+import {
+  CountrySelector,
+  CitySelector,
+  type LocationOption,
+} from "./CountryCitySelectionModal";
 
 const { width: screenWidth } = Dimensions.get("window");
-
-type LocalityOption = {
-  key: string;
-  value: string;
-};
 
 type ClubFormValues = {
   clubName: string;
@@ -77,13 +73,11 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [clubCreationLoading, setClubCreationLoading] = useState(false);
 
-  const [countries, setCountries] = useState<LocalityOption[]>([]);
   const [selectedCountryCode, setSelectedCountryCode] = useState<string | null>(
     null,
   );
-  const [cities, setCities] = useState<LocalityOption[]>([]);
-  const [loadingCities, setLoadingCities] = useState(false);
-  const [loadingCountries, setLoadingCountries] = useState(false);
+  const [showCountrySelector, setShowCountrySelector] = useState(false);
+  const [showCitySelector, setShowCitySelector] = useState(false);
 
   const {
     control,
@@ -116,21 +110,7 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
       reset(defaultValues);
       setSelectedImage(null);
       setSelectedCountryCode(null);
-      setCities([]);
     }
-
-    setLoadingCountries(true);
-    const task = InteractionManager.runAfterInteractions(() => {
-      try {
-        setCountries(loadCountries());
-      } finally {
-        setLoadingCountries(false);
-      }
-    });
-
-    return () => {
-      task.cancel();
-    };
   }, [modalVisible, reset]);
 
   const imagePickInFlightRef = useRef(false);
@@ -184,22 +164,24 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
     }
   }, []);
 
-  const handleCityDropdownOpen = useCallback(async () => {
-    if (!selectedCountryCode) {
-      setCities([]);
-      return;
-    }
+  const handleCountrySelected = useCallback(
+    (selectedCountry: LocationOption) => {
+      setValue("country", selectedCountry.value, { shouldValidate: true });
+      setValue("city", "");
+      setSelectedCountryCode(selectedCountry.key);
+      setShowCountrySelector(false);
+      setShowCitySelector(true);
+    },
+    [setValue],
+  );
 
-    setLoadingCities(true);
-    try {
-      setCities(loadCities(selectedCountryCode));
-    } catch (e) {
-      console.error(e);
-      setCities([]);
-    } finally {
-      setLoadingCities(false);
-    }
-  }, [selectedCountryCode]);
+  const handleCitySelected = useCallback(
+    (selectedCity: LocationOption) => {
+      setValue("city", selectedCity.value, { shouldValidate: true });
+      setShowCitySelector(false);
+    },
+    [setValue],
+  );
 
   const onSubmit = async (data: ClubFormValues) => {
     setClubCreationLoading(true);
@@ -271,7 +253,6 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
 
       reset(defaultValues);
       setSelectedCountryCode(null);
-      setCities([]);
       setSelectedImage(null);
       setModalVisible(false);
       onSuccess?.();
@@ -340,78 +321,38 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
                   required
                 />
 
+                <LabelContainer>
+                  <Label>
+                    Club Home Location<ErrorText>*</ErrorText>
+                  </Label>
+                  {(errors.country || errors.city) && (
+                    <ErrorText>Country and city are required</ErrorText>
+                  )}
+                </LabelContainer>
+
                 <Controller
                   control={control}
                   name="country"
                   rules={{ required: "Country is required" }}
-                  render={({ field: { onChange, value } }) => (
-                    <ListDropdown
-                      label="Country"
-                      setSelected={(val: string) => {
-                        onChange(val);
-                        const selected = countries.find((c) => c.value === val);
-                        setSelectedCountryCode(selected?.key ?? null);
-                        setValue("city", "");
-                        setCities([]);
-                      }}
-                      data={countries}
-                      save="value"
-                      placeholder={
-                        loadingCountries
-                          ? "Loading countries..."
-                          : "Select country"
-                      }
-                      selectedOption={
-                        value ? { key: value, value } : {}
-                      }
-                      boxStyles={[
-                        styles.box,
-                        errors.country ? styles.errorBox : null,
-                      ]}
-                      inputStyles={styles.input}
-                      dropdownStyles={styles.dropdown}
-                      fontFamily=""
-                      loading={loadingCountries}
-                      notFoundText="No countries found"
-                      notFoundTextFunction={() => {}}
-                      onDropdownOpen={() => {}}
-                    />
+                  render={() => (
+                    <LocationButton
+                      hasError={Boolean(errors.country || errors.city)}
+                      onPress={() => setShowCountrySelector(true)}
+                    >
+                      <LocationButtonText selected={Boolean(country && city)}>
+                        {country && city
+                          ? `${city}, ${country}`
+                          : "Select country & city"}
+                      </LocationButtonText>
+                      <AntDesign name="right" size={16} color="#888" />
+                    </LocationButton>
                   )}
                 />
                 <Controller
                   control={control}
                   name="city"
                   rules={{ required: "City is required" }}
-                  render={({ field: { onChange, value } }) => (
-                    <ListDropdown
-                      label="City"
-                      setSelected={(val: string) => onChange(val)}
-                      data={cities}
-                      save="value"
-                      placeholder={
-                        selectedCountryCode
-                          ? "Search cities..."
-                          : "Select country first"
-                      }
-                      searchPlaceholder="Start typing..."
-                      selectedOption={
-                        value ? { key: value, value } : {}
-                      }
-                      boxStyles={[
-                        styles.box,
-                        errors.city ? styles.errorBox : null,
-                        !selectedCountryCode ? styles.disabledBox : null,
-                      ]}
-                      inputStyles={styles.input}
-                      dropdownStyles={styles.dropdown}
-                      fontFamily=""
-                      loading={loadingCities}
-                      onDropdownOpen={handleCityDropdownOpen}
-                      disabled={!selectedCountryCode}
-                      notFoundText="No cities found"
-                      notFoundTextFunction={() => {}}
-                    />
-                  )}
+                  render={() => <></>}
                 />
 
                 <FormField
@@ -440,6 +381,18 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
                 </ButtonContainer>
           </ScrollContainer>
         </SafeAreaWrapper>
+
+        <CountrySelector
+          visible={showCountrySelector}
+          onClose={() => setShowCountrySelector(false)}
+          onSelect={handleCountrySelected}
+        />
+        <CitySelector
+          visible={showCitySelector}
+          onClose={() => setShowCitySelector(false)}
+          countryCode={selectedCountryCode}
+          onSelect={handleCitySelected}
+        />
       </ModalContainer>
     </Modal>
   );
@@ -638,25 +591,27 @@ const ImagePlaceholder = styled.View({
   borderColor: "#ccc",
 });
 
-const styles = StyleSheet.create({
-  box: {
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
-    borderWidth: 0,
-    borderRadius: 5,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-  },
-  errorBox: {
-    borderWidth: 1,
-    borderColor: "#ff7675",
-  },
-  disabledBox: { opacity: 0.6 },
-  input: { color: "#fff", paddingRight: 10 },
-  dropdown: {
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
-    borderWidth: 0,
-    marginTop: 5,
-  },
-});
+const LocationButton = styled.TouchableOpacity<{ hasError?: boolean }>(
+  ({ hasError }: { hasError?: boolean }) => ({
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    height: 40,
+    borderRadius: 6,
+    backgroundColor: "rgba(255, 255, 255, 0.2)",
+    paddingHorizontal: 12,
+    marginBottom: 16,
+    borderWidth: hasError ? 1 : 0,
+    borderColor: hasError ? "#ff7675" : "transparent",
+  }),
+);
+
+const LocationButtonText = styled.Text<{ selected?: boolean }>(
+  ({ selected }: { selected?: boolean }) => ({
+    color: selected ? "#fff" : "#ccc",
+    fontSize: 14,
+    flexShrink: 1,
+  }),
+);
 
 export default AddClubModal;

--- a/components/Modals/AddClubModal.tsx
+++ b/components/Modals/AddClubModal.tsx
@@ -169,7 +169,6 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
       setValue("country", selectedCountry.value, { shouldValidate: true });
       setValue("city", "");
       setSelectedCountryCode(selectedCountry.key);
-      setShowCountrySelector(false);
       setShowCitySelector(true);
     },
     [setValue],
@@ -179,6 +178,7 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
     (selectedCity: LocationOption) => {
       setValue("city", selectedCity.value, { shouldValidate: true });
       setShowCitySelector(false);
+      setShowCountrySelector(false);
     },
     [setValue],
   );
@@ -386,13 +386,14 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
           visible={showCountrySelector}
           onClose={() => setShowCountrySelector(false)}
           onSelect={handleCountrySelected}
-        />
-        <CitySelector
-          visible={showCitySelector}
-          onClose={() => setShowCitySelector(false)}
-          countryCode={selectedCountryCode}
-          onSelect={handleCitySelected}
-        />
+        >
+          <CitySelector
+            visible={showCitySelector}
+            onBack={() => setShowCitySelector(false)}
+            countryCode={selectedCountryCode}
+            onSelect={handleCitySelected}
+          />
+        </CountrySelector>
       </ModalContainer>
     </Modal>
   );

--- a/components/Modals/AddCourtModal.js
+++ b/components/Modals/AddCourtModal.js
@@ -42,7 +42,6 @@ const AddCourtModal = ({
       city: "",
     });
     setSelectedCountryCode(selectedCountry.key);
-    setShowCountrySelector(false);
     setShowCitySelector(true);
   };
 
@@ -52,6 +51,7 @@ const AddCourtModal = ({
       city: selectedCity.value,
     });
     setShowCitySelector(false);
+    setShowCountrySelector(false);
   };
 
   const allFieldsFilled = useMemo(() => {
@@ -180,13 +180,14 @@ const AddCourtModal = ({
           visible={showCountrySelector}
           onClose={() => setShowCountrySelector(false)}
           onSelect={handleCountrySelected}
-        />
-        <CitySelector
-          visible={showCitySelector}
-          onClose={() => setShowCitySelector(false)}
-          countryCode={selectedCountryCode}
-          onSelect={handleCitySelected}
-        />
+        >
+          <CitySelector
+            visible={showCitySelector}
+            onBack={() => setShowCitySelector(false)}
+            countryCode={selectedCountryCode}
+            onSelect={handleCitySelected}
+          />
+        </CountrySelector>
       </ModalContainer>
     </Modal>
   );

--- a/components/Modals/AddCourtModal.js
+++ b/components/Modals/AddCourtModal.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useMemo } from "react";
 import { BlurView } from "expo-blur";
 import styled from "styled-components/native";
 import {
@@ -9,8 +9,10 @@ import {
   View,
   Platform,
 } from "react-native";
-import { loadCountries, loadCities } from "../../utils/locationData";
-import ListDropdown from "../ListDropdown/ListDropdown";
+import {
+  CountrySelector,
+  CitySelector,
+} from "./CountryCitySelectionModal";
 import { Ionicons } from "@expo/vector-icons";
 
 const AddCourtModal = ({
@@ -23,50 +25,33 @@ const AddCourtModal = ({
 }) => {
   const [courtCreationLoading, setCourtCreationLoading] = useState(false);
 
-  // Coutry and city state
-  const [countries, setCountries] = useState([]);
+  // Country and city state
   const [selectedCountryCode, setSelectedCountryCode] = useState(null);
-
-  const [cities, setCities] = useState([]);
-  const [loadingCities, setLoadingCities] = useState(false);
-  const [loadingCountries, setLoadingCountries] = useState(false);
-
-  useEffect(() => {
-    if (!visible) return;
-
-    if (countries.length) return;
-
-    setLoadingCountries(true);
-    setTimeout(() => {
-      try {
-        const all = loadCountries();
-        setCountries(all);
-      } finally {
-        setLoadingCountries(false);
-      }
-    }, 0);
-  }, [visible, countries]);
-
-  const handleCityDropdownOpen = useCallback(async () => {
-    if (!selectedCountryCode) {
-      setCities([]);
-      return;
-    }
-
-    setLoadingCities(true);
-    try {
-      const list = loadCities(selectedCountryCode);
-      setCities(list);
-    } catch (e) {
-      console.error(e);
-      setCities([]);
-    } finally {
-      setLoadingCities(false);
-    }
-  }, [selectedCountryCode]);
+  const [showCountrySelector, setShowCountrySelector] = useState(false);
+  const [showCitySelector, setShowCitySelector] = useState(false);
 
   const handleChange = (key, value) => {
     setCourtDetails((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleCountrySelected = (selectedCountry) => {
+    handleChange("location", {
+      ...courtDetails.location,
+      country: selectedCountry.value,
+      countryCode: selectedCountry.key,
+      city: "",
+    });
+    setSelectedCountryCode(selectedCountry.key);
+    setShowCountrySelector(false);
+    setShowCitySelector(true);
+  };
+
+  const handleCitySelected = (selectedCity) => {
+    handleChange("location", {
+      ...courtDetails.location,
+      city: selectedCity.value,
+    });
+    setShowCitySelector(false);
   };
 
   const allFieldsFilled = useMemo(() => {
@@ -116,66 +101,22 @@ const AddCourtModal = ({
                   autoComplete="off"
                   spellCheck={false}
                 />
-                <ListDropdown
-                  label="Country"
-                  setSelected={(val) => {
-                    const selectedCountry = countries.find(
-                      (c) => c.value === val,
-                    );
-                    handleChange("location", {
-                      ...courtDetails.location,
-                      country: val,
-                      countryCode: selectedCountry?.key,
-                    });
-
-                    setSelectedCountryCode(selectedCountry?.key);
-                    setCities([]);
-                  }}
-                  data={countries}
-                  save="value"
-                  placeholder={
-                    loadingCountries ? "Loading countries..." : "Select country"
-                  }
-                  selectedOption={
-                    courtDetails.location.country
-                      ? {
-                          key: courtDetails.location.countryCode,
-                          value: courtDetails.location.country,
-                        }
-                      : null
-                  }
-                  loading={loadingCountries}
-                />
-
-                {/* City Dropdown */}
-                <ListDropdown
-                  label="City"
-                  setSelected={(val) => {
-                    handleChange("location", {
-                      ...courtDetails.location,
-                      city: val,
-                    });
-                  }}
-                  data={cities}
-                  save="value"
-                  placeholder={
-                    selectedCountryCode
-                      ? "Search cities..."
-                      : "Select country first"
-                  }
-                  searchPlaceholder="Start typing..."
-                  selectedOption={
-                    courtDetails.location.city
-                      ? {
-                          key: courtDetails.location.city,
-                          value: courtDetails.location.city,
-                        }
-                      : null
-                  }
-                  loading={loadingCities}
-                  onDropdownOpen={handleCityDropdownOpen}
-                  disabled={loadingCountries || !selectedCountryCode}
-                />
+                <Label>Country / City</Label>
+                <LocationButton onPress={() => setShowCountrySelector(true)}>
+                  <LocationButtonText
+                    selected={
+                      !!(
+                        courtDetails.location.country &&
+                        courtDetails.location.city
+                      )
+                    }
+                  >
+                    {courtDetails.location.country && courtDetails.location.city
+                      ? `${courtDetails.location.city}, ${courtDetails.location.country}`
+                      : "Select country & city"}
+                  </LocationButtonText>
+                  <Ionicons name="chevron-forward" size={18} color="#888" />
+                </LocationButton>
                 <Label>Post Code/ ZIP Code</Label>
                 <Input
                   value={courtDetails.location.postCode}
@@ -234,6 +175,18 @@ const AddCourtModal = ({
             )}
           />
         </CourtLocationWrapper>
+
+        <CountrySelector
+          visible={showCountrySelector}
+          onClose={() => setShowCountrySelector(false)}
+          onSelect={handleCountrySelected}
+        />
+        <CitySelector
+          visible={showCitySelector}
+          onClose={() => setShowCitySelector(false)}
+          countryCode={selectedCountryCode}
+          onSelect={handleCitySelected}
+        />
       </ModalContainer>
     </Modal>
   );
@@ -283,6 +236,23 @@ const Input = styled.TextInput({
   paddingLeft: 12,
   marginBottom: 16,
 });
+
+const LocationButton = styled.TouchableOpacity({
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  height: 40,
+  borderRadius: 6,
+  backgroundColor: "rgba(255, 255, 255, 0.2)",
+  paddingHorizontal: 12,
+  marginBottom: 16,
+});
+
+const LocationButtonText = styled.Text(({ selected }) => ({
+  color: selected ? "white" : "#ccc",
+  fontSize: 14,
+  flexShrink: 1,
+}));
 
 const ButtonContainer = styled.View({
   flexDirection: "row",

--- a/components/Modals/AddLeagueModal.js
+++ b/components/Modals/AddLeagueModal.js
@@ -262,7 +262,7 @@ const AddLeagueModal = ({ modalVisible, setModalVisible, onSuccess, clubId = nul
                   required
                 />
 
-                <Label>Location</Label>
+                <Label>Court Location</Label>
                 <CourtSelector
                   hasError={!!errors.location}
                   onPress={() => setShowSearchCourtModal(true)}

--- a/components/Modals/AddTournamentModal.js
+++ b/components/Modals/AddTournamentModal.js
@@ -267,7 +267,7 @@ const AddTournamentModal = ({ modalVisible, setModalVisible, onSuccess, clubId =
                   required
                 />
 
-                <Label>Location</Label>
+                <Label>Court Location</Label>
                 <CourtSelector
                   hasError={!!errors.location}
                   onPress={() => setShowSearchCourtModal(true)}

--- a/components/Modals/CountryCitySelectionModal.tsx
+++ b/components/Modals/CountryCitySelectionModal.tsx
@@ -1,5 +1,5 @@
 // components/Modals/CountryCitySelectionModal.tsx
-import React, { useEffect, useMemo, useState } from "react";
+import React, { ReactNode, useEffect, useMemo, useState } from "react";
 import {
   Modal,
   Dimensions,
@@ -31,12 +31,18 @@ interface CountrySelectorProps {
   onClose: () => void;
   /** Fires with the chosen country. `key` is the ISO code, `value` is the name. */
   onSelect: (country: LocationOption) => void;
+  /**
+   * Rendered inside the country modal so the next step (the city selector)
+   * stacks on top of the country list instead of replacing it.
+   */
+  children?: ReactNode;
 }
 
 export const CountrySelector = ({
   visible,
   onClose,
   onSelect,
+  children,
 }: CountrySelectorProps) => {
   const [search, setSearch] = useState("");
   const [countries, setCountries] = useState<LocationOption[]>([]);
@@ -75,10 +81,10 @@ export const CountrySelector = ({
         setSearch("");
       }}
     >
+      <LocationName>{item.value}</LocationName>
       <FlagCircle>
         <Icon name={item.key} height="40" width="40" />
       </FlagCircle>
-      <LocationName>{item.value}</LocationName>
     </LocationItem>
   );
 
@@ -115,6 +121,7 @@ export const CountrySelector = ({
           {loading ? (
             <LoadingWrap>
               <ActivityIndicator size="small" color="#00A2FF" />
+              <LoadingText>Loading countries</LoadingText>
             </LoadingWrap>
           ) : (
             <FlatList
@@ -129,6 +136,8 @@ export const CountrySelector = ({
             />
           )}
         </Wrapper>
+
+        {children}
       </ModalContainer>
     </Modal>
   );
@@ -140,7 +149,8 @@ export const CountrySelector = ({
 
 interface CitySelectorProps {
   visible: boolean;
-  onClose: () => void;
+  /** Back button — returns to the country list underneath. */
+  onBack: () => void;
   /** ISO code of the previously selected country; drives which cities load. */
   countryCode: string | null;
   /** Fires with the chosen city. */
@@ -149,7 +159,7 @@ interface CitySelectorProps {
 
 export const CitySelector = ({
   visible,
-  onClose,
+  onBack,
   countryCode,
   onSelect,
 }: CitySelectorProps) => {
@@ -205,18 +215,18 @@ export const CitySelector = ({
       visible={visible}
       transparent
       animationType="slide"
-      onRequestClose={onClose}
+      onRequestClose={onBack}
     >
       <ModalContainer behavior={Platform.OS === "ios" ? "padding" : "height"}>
         <Wrapper>
           <Header>
-            <ModalTitle>Select City</ModalTitle>
-            <TouchableOpacity
-              onPress={onClose}
+            <BackRow
+              onPress={onBack}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             >
-              <AntDesign name="close-circle" size={26} color="red" />
-            </TouchableOpacity>
+              <AntDesign name="arrow-left" size={22} color="#fff" />
+              <ModalTitle>Select City</ModalTitle>
+            </BackRow>
           </Header>
 
           <SearchInput
@@ -233,6 +243,7 @@ export const CitySelector = ({
           {loading ? (
             <LoadingWrap>
               <ActivityIndicator size="small" color="#00A2FF" />
+              <LoadingText>Loading cities</LoadingText>
             </LoadingWrap>
           ) : (
             <FlatList
@@ -279,6 +290,12 @@ const Header = styled.View({
   marginBottom: 16,
 });
 
+const BackRow = styled.TouchableOpacity({
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 10,
+});
+
 const ModalTitle = styled.Text({
   fontSize: 20,
   color: "#fff",
@@ -298,6 +315,7 @@ const SearchInput = styled.TextInput({
 const LocationItem = styled.TouchableOpacity({
   flexDirection: "row",
   alignItems: "center",
+  justifyContent: "space-between",
   gap: 12,
   padding: 14,
   marginBottom: 8,
@@ -324,8 +342,15 @@ const FlagCircle = styled.View({
 
 const LoadingWrap = styled.View({
   flex: 1,
+  flexDirection: "row",
   alignItems: "center",
   justifyContent: "center",
+  gap: 10,
+});
+
+const LoadingText = styled.Text({
+  color: "#ccc",
+  fontSize: 15,
 });
 
 const EmptyText = styled.Text({

--- a/components/Modals/CountryCitySelectionModal.tsx
+++ b/components/Modals/CountryCitySelectionModal.tsx
@@ -1,0 +1,335 @@
+// components/Modals/CountryCitySelectionModal.tsx
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Modal,
+  Dimensions,
+  Platform,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  ListRenderItem,
+} from "react-native";
+import { BlurView } from "expo-blur";
+import styled from "styled-components/native";
+import { AntDesign } from "@expo/vector-icons";
+import Icon from "react-native-ico-flags";
+import { loadCountries, loadCities } from "../../utils/locationData";
+
+const { width: screenWidth } = Dimensions.get("window");
+
+export interface LocationOption {
+  key: string;
+  value: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/*                               CountrySelector                              */
+/* -------------------------------------------------------------------------- */
+
+interface CountrySelectorProps {
+  visible: boolean;
+  onClose: () => void;
+  /** Fires with the chosen country. `key` is the ISO code, `value` is the name. */
+  onSelect: (country: LocationOption) => void;
+}
+
+export const CountrySelector = ({
+  visible,
+  onClose,
+  onSelect,
+}: CountrySelectorProps) => {
+  const [search, setSearch] = useState("");
+  const [countries, setCountries] = useState<LocationOption[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setSearch("");
+      return;
+    }
+
+    if (countries.length) return;
+
+    setLoading(true);
+    const timeout = setTimeout(() => {
+      try {
+        setCountries(loadCountries());
+      } finally {
+        setLoading(false);
+      }
+    }, 0);
+
+    return () => clearTimeout(timeout);
+  }, [visible, countries.length]);
+
+  const filteredCountries = useMemo(() => {
+    const term = search.toLowerCase().trim();
+    if (!term) return countries;
+    return countries.filter((c) => c.value.toLowerCase().startsWith(term));
+  }, [search, countries]);
+
+  const renderItem: ListRenderItem<LocationOption> = ({ item }) => (
+    <LocationItem
+      onPress={() => {
+        onSelect(item);
+        setSearch("");
+      }}
+    >
+      <FlagCircle>
+        <Icon name={item.key} height="40" width="40" />
+      </FlagCircle>
+      <LocationName>{item.value}</LocationName>
+    </LocationItem>
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <ModalContainer behavior={Platform.OS === "ios" ? "padding" : "height"}>
+        <Wrapper>
+          <Header>
+            <ModalTitle>Select Country</ModalTitle>
+            <TouchableOpacity
+              onPress={onClose}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <AntDesign name="close-circle" size={26} color="red" />
+            </TouchableOpacity>
+          </Header>
+
+          <SearchInput
+            placeholder="Search countries..."
+            placeholderTextColor="#999"
+            value={search}
+            onChangeText={setSearch}
+            autoCorrect={false}
+            autoCapitalize="none"
+            autoComplete="off"
+            spellCheck={false}
+          />
+
+          {loading ? (
+            <LoadingWrap>
+              <ActivityIndicator size="small" color="#00A2FF" />
+            </LoadingWrap>
+          ) : (
+            <FlatList
+              data={filteredCountries}
+              keyExtractor={(item) => item.key}
+              renderItem={renderItem}
+              keyboardShouldPersistTaps="handled"
+              style={{ flex: 1 }}
+              contentContainerStyle={{ paddingBottom: 12 }}
+              showsVerticalScrollIndicator={false}
+              ListEmptyComponent={<EmptyText>No countries found</EmptyText>}
+            />
+          )}
+        </Wrapper>
+      </ModalContainer>
+    </Modal>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                CitySelector                                */
+/* -------------------------------------------------------------------------- */
+
+interface CitySelectorProps {
+  visible: boolean;
+  onClose: () => void;
+  /** ISO code of the previously selected country; drives which cities load. */
+  countryCode: string | null;
+  /** Fires with the chosen city. */
+  onSelect: (city: LocationOption) => void;
+}
+
+export const CitySelector = ({
+  visible,
+  onClose,
+  countryCode,
+  onSelect,
+}: CitySelectorProps) => {
+  const [search, setSearch] = useState("");
+  const [cities, setCities] = useState<LocationOption[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setSearch("");
+      return;
+    }
+
+    if (!countryCode) {
+      setCities([]);
+      return;
+    }
+
+    setLoading(true);
+    const timeout = setTimeout(() => {
+      try {
+        setCities(loadCities(countryCode));
+      } catch (e) {
+        console.error(e);
+        setCities([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 0);
+
+    return () => clearTimeout(timeout);
+  }, [visible, countryCode]);
+
+  const filteredCities = useMemo(() => {
+    const term = search.toLowerCase().trim();
+    if (!term) return cities;
+    return cities.filter((c) => c.value.toLowerCase().startsWith(term));
+  }, [search, cities]);
+
+  const renderItem: ListRenderItem<LocationOption> = ({ item }) => (
+    <LocationItem
+      onPress={() => {
+        onSelect(item);
+        setSearch("");
+      }}
+    >
+      <LocationName>{item.value}</LocationName>
+    </LocationItem>
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <ModalContainer behavior={Platform.OS === "ios" ? "padding" : "height"}>
+        <Wrapper>
+          <Header>
+            <ModalTitle>Select City</ModalTitle>
+            <TouchableOpacity
+              onPress={onClose}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            >
+              <AntDesign name="close-circle" size={26} color="red" />
+            </TouchableOpacity>
+          </Header>
+
+          <SearchInput
+            placeholder="Search cities..."
+            placeholderTextColor="#999"
+            value={search}
+            onChangeText={setSearch}
+            autoCorrect={false}
+            autoCapitalize="none"
+            autoComplete="off"
+            spellCheck={false}
+          />
+
+          {loading ? (
+            <LoadingWrap>
+              <ActivityIndicator size="small" color="#00A2FF" />
+            </LoadingWrap>
+          ) : (
+            <FlatList
+              data={filteredCities}
+              keyExtractor={(item) => item.key}
+              renderItem={renderItem}
+              keyboardShouldPersistTaps="handled"
+              style={{ flex: 1 }}
+              contentContainerStyle={{ paddingBottom: 12 }}
+              showsVerticalScrollIndicator={false}
+              ListEmptyComponent={<EmptyText>No cities found</EmptyText>}
+            />
+          )}
+        </Wrapper>
+      </ModalContainer>
+    </Modal>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                   Styles                                    */
+/* -------------------------------------------------------------------------- */
+
+const ModalContainer = styled(BlurView).attrs({ intensity: 80, tint: "dark" })({
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+});
+
+const Wrapper = styled.View({
+  width: screenWidth - 40,
+  height: "75%",
+  margin: 20,
+  borderRadius: 20,
+  overflow: "hidden",
+  backgroundColor: "rgba(2, 13, 24, 0.95)",
+  padding: 20,
+});
+
+const Header = styled.View({
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  marginBottom: 16,
+});
+
+const ModalTitle = styled.Text({
+  fontSize: 20,
+  color: "#fff",
+  fontWeight: "bold",
+});
+
+const SearchInput = styled.TextInput({
+  height: 42,
+  borderRadius: 8,
+  backgroundColor: "rgba(255, 255, 255, 0.1)",
+  color: "white",
+  paddingHorizontal: 12,
+  marginBottom: 16,
+  fontSize: 15,
+});
+
+const LocationItem = styled.TouchableOpacity({
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 12,
+  padding: 14,
+  marginBottom: 8,
+  borderRadius: 8,
+  backgroundColor: "rgba(255, 255, 255, 0.05)",
+});
+
+const LocationName = styled.Text({
+  color: "#fff",
+  fontSize: 15,
+  fontWeight: "600",
+  flexShrink: 1,
+});
+
+const FlagCircle = styled.View({
+  width: 28,
+  height: 28,
+  borderRadius: 14,
+  overflow: "hidden",
+  alignItems: "center",
+  justifyContent: "center",
+  backgroundColor: "rgba(255, 255, 255, 0.08)",
+});
+
+const LoadingWrap = styled.View({
+  flex: 1,
+  alignItems: "center",
+  justifyContent: "center",
+});
+
+const EmptyText = styled.Text({
+  color: "#888",
+  textAlign: "center",
+  marginTop: 20,
+});

--- a/components/Modals/CountryCitySelectionModal.tsx
+++ b/components/Modals/CountryCitySelectionModal.tsx
@@ -7,13 +7,15 @@ import {
   TouchableOpacity,
   FlatList,
   ActivityIndicator,
+  InteractionManager,
   ListRenderItem,
 } from "react-native";
 import { BlurView } from "expo-blur";
 import styled from "styled-components/native";
-import { AntDesign } from "@expo/vector-icons";
+import { AntDesign, Ionicons } from "@expo/vector-icons";
 import Icon from "react-native-ico-flags";
 import { loadCountries, loadCities } from "../../utils/locationData";
+import { hasFlag } from "../../utils/flagCountryCodes";
 
 const { width: screenWidth } = Dimensions.get("window");
 
@@ -83,7 +85,9 @@ export const CountrySelector = ({
     >
       <LocationName>{item.value}</LocationName>
       <FlagCircle>
-        <Icon name={item.key} height="40" width="40" />
+        {hasFlag(item.key) ? (
+          <Icon name={item.key} height="40" width="40" />
+        ) : null}
       </FlagCircle>
     </LocationItem>
   );
@@ -178,8 +182,11 @@ export const CitySelector = ({
       return;
     }
 
+    // Show the loading state immediately so the modal opens sharply, then do
+    // the heavy city lookup once the open animation/interactions have settled.
     setLoading(true);
-    const timeout = setTimeout(() => {
+    setCities([]);
+    const task = InteractionManager.runAfterInteractions(() => {
       try {
         setCities(loadCities(countryCode));
       } catch (e) {
@@ -188,9 +195,9 @@ export const CitySelector = ({
       } finally {
         setLoading(false);
       }
-    }, 0);
+    });
 
-    return () => clearTimeout(timeout);
+    return () => task.cancel();
   }, [visible, countryCode]);
 
   const filteredCities = useMemo(() => {
@@ -224,7 +231,7 @@ export const CitySelector = ({
               onPress={onBack}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             >
-              <AntDesign name="arrow-left" size={22} color="#fff" />
+              <Ionicons name="chevron-back" size={24} color="#fff" />
               <ModalTitle>Select City</ModalTitle>
             </BackRow>
           </Header>

--- a/screens/Authentication/Signup.js
+++ b/screens/Authentication/Signup.js
@@ -89,7 +89,6 @@ const Signup = ({ route }) => {
       setValue("country", selectedCountry.value, { shouldValidate: true });
       setValue("city", "");
       setSelectedCountryCode(selectedCountry.key);
-      setShowCountrySelector(false);
       setShowCitySelector(true);
     },
     [setValue],
@@ -99,6 +98,7 @@ const Signup = ({ route }) => {
     (selectedCity) => {
       setValue("city", selectedCity.value, { shouldValidate: true });
       setShowCitySelector(false);
+      setShowCountrySelector(false);
     },
     [setValue],
   );
@@ -402,13 +402,14 @@ const Signup = ({ route }) => {
         visible={showCountrySelector}
         onClose={() => setShowCountrySelector(false)}
         onSelect={handleCountrySelected}
-      />
-      <CitySelector
-        visible={showCitySelector}
-        onClose={() => setShowCitySelector(false)}
-        countryCode={selectedCountryCode}
-        onSelect={handleCitySelected}
-      />
+      >
+        <CitySelector
+          visible={showCitySelector}
+          onBack={() => setShowCitySelector(false)}
+          countryCode={selectedCountryCode}
+          onSelect={handleCitySelected}
+        />
+      </CountrySelector>
     </Container>
   );
 };

--- a/screens/Authentication/Signup.js
+++ b/screens/Authentication/Signup.js
@@ -1,12 +1,11 @@
-import React, { useContext, useState, useEffect, useCallback } from "react";
+import React, { useContext, useState, useCallback } from "react";
 import { UserContext } from "../../context/UserContext";
+import { KeyboardAvoidingView, Platform, FlatList } from "react-native";
 import {
-  KeyboardAvoidingView,
-  Platform,
-  FlatList,
-  StyleSheet,
-} from "react-native";
-import ListDropdown from "../../components/ListDropdown/ListDropdown";
+  CountrySelector,
+  CitySelector,
+} from "../../components/Modals/CountryCitySelectionModal";
+import { AntDesign } from "@expo/vector-icons";
 import { useForm, Controller } from "react-hook-form";
 import styled from "styled-components/native";
 import { auth, db } from "../../services/firebase.config";
@@ -36,7 +35,6 @@ import {
   notificationTypes,
   ccImageEndpoint,
 } from "@shared";
-import { loadCountries, loadCities } from "../../utils/locationData";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { registerForPushNotificationsAsync } from "../../services/pushNotifications";
 
@@ -54,12 +52,9 @@ const Signup = ({ route }) => {
   const [popupIcon, setPopupIcon] = useState("");
   const [popupButtonText, setPopupButtonText] = useState("");
 
-  const [countries, setCountries] = useState([]);
   const [selectedCountryCode, setSelectedCountryCode] = useState(null);
-
-  const [cities, setCities] = useState([]);
-  const [loadingCities, setLoadingCities] = useState(false);
-  const [loadingCountries, setLoadingCountries] = useState(false);
+  const [showCountrySelector, setShowCountrySelector] = useState(false);
+  const [showCitySelector, setShowCitySelector] = useState(false);
 
   const navigation = useNavigation();
 
@@ -89,37 +84,24 @@ const Signup = ({ route }) => {
     setValue,
   } = useForm({ defaultValues: defaults });
 
-  useEffect(() => {
-    if (countries.length) return;
+  const handleCountrySelected = useCallback(
+    (selectedCountry) => {
+      setValue("country", selectedCountry.value, { shouldValidate: true });
+      setValue("city", "");
+      setSelectedCountryCode(selectedCountry.key);
+      setShowCountrySelector(false);
+      setShowCitySelector(true);
+    },
+    [setValue],
+  );
 
-    setLoadingCountries(true);
-    setTimeout(() => {
-      try {
-        const all = loadCountries();
-        setCountries(all);
-      } finally {
-        setLoadingCountries(false);
-      }
-    }, 0);
-  }, [countries]);
-
-  const handleCityDropdownOpen = useCallback(async () => {
-    if (!selectedCountryCode) {
-      setCities([]);
-      return;
-    }
-
-    setLoadingCities(true);
-    try {
-      const list = loadCities(selectedCountryCode);
-      setCities(list);
-    } catch (e) {
-      console.error(e);
-      setCities([]);
-    } finally {
-      setLoadingCities(false);
-    }
-  }, [selectedCountryCode]);
+  const handleCitySelected = useCallback(
+    (selectedCity) => {
+      setValue("city", selectedCity.value, { shouldValidate: true });
+      setShowCitySelector(false);
+    },
+    [setValue],
+  );
 
   const handleCloseSignUpConfirmationPopup = () => {
     setShowPopup(false);
@@ -374,77 +356,37 @@ const Signup = ({ route }) => {
                   passwordValidation={passwordValidation}
                 />
               )}
+              <Label>Location</Label>
               <Controller
                 name={"country"}
                 control={control}
-                label="Country"
                 rules={{ required: "Country is required" }}
-                render={({ field: { onChange, value } }) => (
-                  <ListDropdown
-                    label="Country"
-                    setSelected={(val) => {
-                      onChange(val);
-                      const selectedCountry = countries.find(
-                        (c) => c.value === val,
-                      );
-                      const countryCode = selectedCountry?.key;
-                      setSelectedCountryCode(countryCode);
-                      setValue("city", "");
-                      setCities([]);
-                    }}
-                    data={countries}
-                    save="value"
-                    placeholder={
-                      loadingCountries
-                        ? "Loading countries..."
-                        : "Select country"
-                    }
-                    selectedOption={value ? { key: value, value } : null}
-                    boxStyles={[
-                      styles.box,
-                      errors.country ? styles.errorBox : null,
-                    ]}
-                    inputStyles={styles.input}
-                    dropdownStyles={styles.dropdown}
-                    dropdownTextStyles={styles.dropdownText}
-                    loading={loadingCountries}
+                render={({ field: { value: countryValue } }) => (
+                  <Controller
+                    control={control}
+                    name={"city"}
+                    rules={{ required: "City is required" }}
+                    render={({ field: { value: cityValue } }) => (
+                      <LocationButton
+                        hasError={!!(errors.country || errors.city)}
+                        onPress={() => setShowCountrySelector(true)}
+                      >
+                        <LocationButtonText
+                          selected={!!(countryValue && cityValue)}
+                        >
+                          {countryValue && cityValue
+                            ? `${cityValue}, ${countryValue}`
+                            : "Select country & city"}
+                        </LocationButtonText>
+                        <AntDesign name="right" size={16} color="#888" />
+                      </LocationButton>
+                    )}
                   />
                 )}
               />
-              <Controller
-                control={control}
-                name={"city"}
-                label="City"
-                rules={{ required: "City is required" }}
-                render={({ field: { onChange, value } }) => (
-                  <ListDropdown
-                    label="City"
-                    setSelected={(val) => {
-                      onChange(val);
-                    }}
-                    data={cities}
-                    save="value"
-                    placeholder={
-                      selectedCountryCode
-                        ? "Search cities..."
-                        : "Select country first"
-                    }
-                    searchPlaceholder="Start typing..."
-                    selectedOption={value ? { key: value, value } : null}
-                    boxStyles={[
-                      styles.box,
-                      errors.country ? styles.errorBox : null,
-                      !selectedCountryCode ? styles.disabledBox : null,
-                    ]}
-                    inputStyles={styles.input}
-                    dropdownStyles={styles.dropdown}
-                    dropdownTextStyles={styles.dropdownText}
-                    loading={loadingCities}
-                    onDropdownOpen={handleCityDropdownOpen}
-                    disabled={!selectedCountryCode}
-                  />
-                )}
-              />
+              {(errors.country || errors.city) && (
+                <ErrorText>Country and city are required</ErrorText>
+              )}
               <HandPreference control={control} />
               <Button onPress={handleSubmit(onSubmit)} disabled={isSubmitting}>
                 <ButtonText>
@@ -455,6 +397,18 @@ const Signup = ({ route }) => {
           )}
         />
       </KeyboardAvoidingView>
+
+      <CountrySelector
+        visible={showCountrySelector}
+        onClose={() => setShowCountrySelector(false)}
+        onSelect={handleCountrySelected}
+      />
+      <CitySelector
+        visible={showCitySelector}
+        onClose={() => setShowCitySelector(false)}
+        countryCode={selectedCountryCode}
+        onSelect={handleCitySelected}
+      />
     </Container>
   );
 };
@@ -620,24 +574,21 @@ const ButtonText = styled.Text({
   fontWeight: "bold",
   fontSize: 16,
 });
-
-const styles = StyleSheet.create({
-  box: {
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
-    borderWidth: 0,
-    borderRadius: 5,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-  },
-  errorBox: { borderWidth: 1, borderColor: "#ff7675" },
-  disabledBox: { opacity: 0.6 },
-  input: { color: "#fff", paddingRight: 10 },
-  dropdown: {
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
-    borderWidth: 0,
-    marginTop: 5,
-  },
-  dropdownText: { color: "#fff" },
-});
+const LocationButton = styled.TouchableOpacity(({ hasError }) => ({
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: 10,
+  marginBottom: 10,
+  backgroundColor: "rgba(255, 255, 255, 0.1)",
+  borderRadius: 5,
+  borderWidth: hasError ? 1 : 0,
+  borderColor: hasError ? "#ff7675" : "transparent",
+}));
+const LocationButtonText = styled.Text(({ selected }) => ({
+  color: selected ? "#fff" : "#aaa",
+  fontSize: 14,
+  flexShrink: 1,
+}));
 
 export default Signup;

--- a/utils/flagCountryCodes.js
+++ b/utils/flagCountryCodes.js
@@ -1,0 +1,11 @@
+// utils/flagCountryCodes.js
+// react-native-ico-flags keys its flag assets by uppercase ISO code (via its
+// internal `synonyms` map). Passing a code it doesn't know renders a "?"
+// placeholder, so this set lets callers decide whether to show a flag or fall
+// back to an empty avatar circle instead.
+import flagSynonyms from "react-native-ico-flags/src/synonyms";
+
+const flagIsoCodes = new Set(Object.keys(flagSynonyms));
+
+export const hasFlag = (isoCode) =>
+  typeof isoCode === "string" && flagIsoCodes.has(isoCode.toUpperCase());


### PR DESCRIPTION
## Summary

Replaces the country/city `ListDropdown` selection with a sequential search-modal flow (`CountryCitySelectionModal`) and adopts it across the app. The old `ListDropdown` rendered a virtualized list nested inside a scroll container, which threw *"VirtualizedLists should never be nested inside plain ScrollViews"*. The new modal-based pattern (mirroring `SearchLocationModal.tsx`) fixes that.

## What's new

**`components/Modals/CountryCitySelectionModal.tsx`** — two components in one file, both mirroring `SearchLocationModal` (full-screen `Modal` + `BlurView` + search `TextInput` + `useMemo`-filtered `FlatList`):
- **`CountrySelector`** — country list with flags, loaded from `loadCountries()`.
- **`CitySelector`** — city list (no flags) for the chosen country, loaded from `loadCities(countryCode)`.

**Flow:** the location button opens `CountrySelector`; picking a country opens `CitySelector` **stacked on top** of the still-open country modal (following the existing `AddLeague → SearchCourt → AddCourt` nesting pattern); picking a city closes both and returns `{ country, city, countryCode }`.

## Adoption
- **`AddClubModal.tsx`** — the two separate Country/City dropdowns are replaced by a single **"Club Home Location"** field. Preserves the react-hook-form `country`/`city` fields + required validation, `selectedCountryCode` state, and the `${city}, ${country}` `clubLocation` string.
- **`screens/Authentication/Signup.js`** — both dropdowns replaced by the flow. Preserves the `country`/`city` fields + validation, `selectedCountryCode`, and the `location: { country, city, countryCode }` submit payload.
- **`components/Modals/AddCourtModal.js`** — both dropdowns replaced by a country/city-scoped trigger, still writing `country`/`countryCode`/`city` into `courtDetails.location`. The `postCode`/`address` inputs are left untouched.
- **`AddLeagueModal.js` / `AddTournamentModal.js`** — the **"Location"** label is renamed to **"Court Location"** (label-only change; the underlying court mechanism is unchanged). A club has one home location, but its competitions can run at multiple court locations — hence the distinction.

Removed the now-unused `ListDropdown` imports (plus dead state/helpers/styles) from the three adopting files.

## UX polish
- Country flags sit on the **right** of each row.
- Flags render only when `react-native-ico-flags` actually has an asset for the ISO code (`utils/flagCountryCodes.js`); otherwise an **empty avatar circle** is shown instead of the library's "?" placeholder.
- City selector has a **chevron-back** button that returns to the country list underneath.
- City lookup is deferred via `InteractionManager.runAfterInteractions` so the city modal opens sharply and shows a **"Loading cities"** state instead of blocking the open transition; the country list shows **"Loading countries"** on first load.

## Checks
- `npx tsc --noEmit`: no new errors. (The pre-existing `AddClubModal` errors — `cacheDirectory`/`documentDirectory`, `pluscircleo` — and the `functions/src/*` errors are unrelated main tech debt.)
- `npm run lint`: no new errors. The only lint output from the new file is two `no-unused-vars` warnings on callback **type-signature** parameter names — the same benign pattern already present in `SearchLocationModal.tsx`.

## Acceptance
- No VirtualizedList nesting warnings when selecting location in AddClub, Signup, or AddCourt.
- AddClub shows a single "Club Home Location" field; AddLeague/AddTournament show "Court Location".
- Country picker shows flags (empty circle when none); city picker does not; picking a city closes both modals with the selection applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPMe26iEEymPkDNvSnCKum)_