### PR TITLE
Fix AddClubModal image copy for expo-file-system v19 API

### DIFF
--- a/components/Modals/AddClubModal.tsx
+++ b/components/Modals/AddClubModal.tsx
@@ -15,7 +15,7 @@ import {
   Alert,
   ScrollView,
 } from "react-native";
-import * as FileSystem from "expo-file-system";
+import { File, Paths } from "expo-file-system";
 import { BlurView } from "expo-blur";
 import styled from "styled-components/native";
 import * as ImagePicker from "expo-image-picker";
@@ -142,13 +142,16 @@ const AddClubModal: React.FC<AddClubModalProps> = ({
             [{ resize: { width: 600 } }],
             { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG },
           );
-          const base =
-            FileSystem.cacheDirectory ?? FileSystem.documentDirectory ?? "";
-          if (base) {
-            const stableUri = `${base}club-draft-${Date.now()}.jpg`;
-            await FileSystem.copyAsync({ from: cropped.uri, to: stableUri });
-            setSelectedImage(stableUri);
-          } else {
+          // Copy the manipulated image into the cache directory so we hold a
+          // stable URI (the picker/manipulator temp file can be reclaimed).
+          try {
+            const stableFile = new File(
+              Paths.cache,
+              `club-draft-${Date.now()}.jpg`,
+            );
+            new File(cropped.uri).copy(stableFile);
+            setSelectedImage(stableFile.uri);
+          } catch {
             setSelectedImage(cropped.uri);
           }
         } catch (e) {


### PR DESCRIPTION
## Summary

`expo-file-system` v19 (SDK 54) removed `cacheDirectory`, `documentDirectory`, and `copyAsync` from the package's main entry, which broke the club image picker in `AddClubModal.tsx`:

```
Property 'cacheDirectory' does not exist on type
'typeof import(".../node_modules/expo-file-system/build/index")'
```

`AddClubModal` was the only file still importing the legacy `expo-file-system` namespace — the rest of the app (`EditProfile`, `EditLeague`, `EditTournament`, `VideoUploadModal`) already uses the new `File` API.

## Change

Migrate `handleImagePick` to the new `File`/`Paths` API:

```ts
import { File, Paths } from "expo-file-system";
// ...
const stableFile = new File(Paths.cache, `club-draft-${Date.now()}.jpg`);
new File(cropped.uri).copy(stableFile);
setSelectedImage(stableFile.uri);
```

Behaviour is unchanged — the manipulated image is still copied into the cache directory to hold a stable URI (the picker/manipulator temp file can be reclaimed), with a fallback to the manipulated URI if the copy fails.

## Checks
- `npx tsc --noEmit`: the `cacheDirectory`/`documentDirectory` errors are resolved.
- `npm run lint`: clean for `AddClubModal.tsx`.

_Note: two unrelated pre-existing type errors remain in this file (an outdated `pluscircleo` AntDesign icon name on the image-picker overlay) — left untouched as they're out of scope for this fix._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPMe26iEEymPkDNvSnCKum)_