### PR TITLE
Club feature: settings actions, delete cleanup, Summary tab + fixes

### DIFF
--- a/components/Modals/RemovePlayerModal.js
+++ b/components/Modals/RemovePlayerModal.js
@@ -18,7 +18,13 @@ const REASONS = [
   { key: "other", value: "Other" },
 ];
 
-const RemovePlayerModal = ({ visible, onClose, onConfirm, playerName }) => {
+const RemovePlayerModal = ({
+  visible,
+  onClose,
+  onConfirm,
+  playerName,
+  entityLabel = "league",
+}) => {
   const [selectedReasonKey, setSelectedReasonKey] = useState("");
   const [description, setDescription] = useState("");
 
@@ -43,10 +49,11 @@ const RemovePlayerModal = ({ visible, onClose, onConfirm, playerName }) => {
         >
           <ModalContent>
             <Title>
-              Are you sure you want to remove {playerName} from the league?
+              Are you sure you want to remove {playerName} from the{" "}
+              {entityLabel}?
             </Title>
             <InfoText>
-              They will lose all their league progress but their personal
+              They will lose all their {entityLabel} progress but their personal
               progress will remain intact.
             </InfoText>
 

--- a/components/Profiles/ProfileActivity.tsx
+++ b/components/Profiles/ProfileActivity.tsx
@@ -30,6 +30,7 @@ import ProfileActivitySkeleton from "../Skeletons/ProfileActivitySkeleton";
 import LineTabs from "../LineTabs";
 import {
   getUserClubActivity,
+  getMemberClubIds,
   ClubActivity,
 } from "../../helpers/clubPlayerStats";
 
@@ -143,17 +144,21 @@ const ProfileActivity: React.FC<ProfileActivityProps> = ({ profile }) => {
 
       setClubsLoading(true);
       try {
-        const [leagues, tournaments] = await Promise.all([
+        const [leagues, tournaments, memberClubIds] = await Promise.all([
           getLeaguesForUser(userId),
           getTournamentsForUser(userId),
+          // Clubs the user is a direct member of — covers clubs they've joined
+          // (or own) but have no competitions in yet.
+          getMemberClubIds(userId),
         ]);
 
         const clubIds = Array.from(
-          new Set(
-            [...leagues, ...tournaments]
+          new Set([
+            ...[...leagues, ...tournaments]
               .map((c: { clubId?: string | null }) => c.clubId)
               .filter((id): id is string => !!id),
-          ),
+            ...memberClubIds,
+          ]),
         );
 
         const activities = await Promise.all(

--- a/context/LeagueContext.tsx
+++ b/context/LeagueContext.tsx
@@ -2252,6 +2252,35 @@ const LeagueProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
+  // Fully delete a club: its heavy subcollections (participants / feed / chat)
+  // and then the root doc. Firestore's client SDK has no recursive delete, so
+  // each subcollection is read and batch-deleted (500-op batch limit).
+  const deleteClub = async (clubId: string): Promise<void> => {
+    try {
+      const clubRef = doc(db, COLLECTION_NAMES.clubs, clubId);
+      const subcollections = ["participants", "feed", "chat"];
+
+      for (const sub of subcollections) {
+        const snap = await getDocs(
+          collection(db, COLLECTION_NAMES.clubs, clubId, sub),
+        );
+        // Chunk deletes well under the 500-write batch cap.
+        for (let i = 0; i < snap.docs.length; i += 450) {
+          const batch = writeBatch(db);
+          snap.docs
+            .slice(i, i + 450)
+            .forEach((docSnap) => batch.delete(docSnap.ref));
+          await batch.commit();
+        }
+      }
+
+      await deleteDoc(clubRef);
+    } catch (error) {
+      console.error("Error deleting club:", error);
+      throw error;
+    }
+  };
+
   const fetchUserPendingRequests = async (userId: string) => {
     try {
       const [leaguesSnap, tournamentsSnap] = await Promise.all([
@@ -2736,6 +2765,7 @@ const LeagueProvider = ({ children }: { children: ReactNode }) => {
         assignClubAdmin,
         revokeClubAdmin,
         removeClubMember,
+        deleteClub,
         requestToJoinLeague,
         acceptCompetitionJoinRequest,
         declineCompetitionJoinRequest,

--- a/context/LeagueContext.tsx
+++ b/context/LeagueContext.tsx
@@ -2134,6 +2134,124 @@ const LeagueProvider = ({ children }: { children: ReactNode }) => {
     });
   };
 
+  // ---------------------------------------------------------------------------
+  // CLUB MANAGEMENT (edit / admins / members)
+  //
+  // Clubs use a different shape to competitions: `clubOwner` / `clubAdmins` live
+  // on the club doc, while members live in the `clubs/{clubId}/participants`
+  // subcollection. These helpers mirror the competition equivalents above.
+  // ---------------------------------------------------------------------------
+
+  // Update a club document (e.g. description / image edits from EditClub).
+  const updateClub = async (club: Club): Promise<void> => {
+    try {
+      if (!club?.clubId) {
+        console.error("updateClub: missing clubId");
+        return;
+      }
+      const clubRef = doc(db, COLLECTION_NAMES.clubs, club.clubId);
+      await updateDoc(clubRef, { ...club } as DocumentData);
+    } catch (error) {
+      console.error("Error updating club:", error);
+      Alert.alert("Error", "Unable to update the club.");
+    }
+  };
+
+  // Club members live in the `clubs/{clubId}/participants` subcollection.
+  const fetchClubParticipants = async (clubId: string): Promise<Player[]> => {
+    try {
+      const snap = await getDocs(
+        collection(db, COLLECTION_NAMES.clubs, clubId, "participants"),
+      );
+      return snap.docs.map(
+        (participant) =>
+          ({ userId: participant.id, ...participant.data() }) as Player,
+      );
+    } catch (error) {
+      console.error("Error fetching club participants:", error);
+      return [];
+    }
+  };
+
+  const assignClubAdmin = async ({
+    clubId,
+    user,
+  }: {
+    clubId: string;
+    user: { userId: string; username: string };
+  }): Promise<void> => {
+    const clubRef = doc(db, COLLECTION_NAMES.clubs, clubId);
+    const clubSnap = await getDoc(clubRef);
+    const clubData = clubSnap.data();
+
+    const updatedAdmins: CompetitionAdmins[] = [
+      ...(clubData?.clubAdmins || []),
+      { userId: user.userId, username: user.username },
+    ];
+
+    await updateDoc(clubRef, { clubAdmins: updatedAdmins });
+  };
+
+  const revokeClubAdmin = async ({
+    clubId,
+    userId,
+  }: {
+    clubId: string;
+    userId: string;
+  }): Promise<void> => {
+    const clubRef = doc(db, COLLECTION_NAMES.clubs, clubId);
+    const clubSnap = await getDoc(clubRef);
+    const clubData = clubSnap.data();
+
+    const updatedAdmins = (clubData?.clubAdmins || []).filter(
+      (admin: CompetitionAdmins) => admin.userId !== userId,
+    );
+
+    await updateDoc(clubRef, { clubAdmins: updatedAdmins });
+  };
+
+  const removeClubMember = async ({
+    clubId,
+    userId,
+    reason,
+  }: {
+    clubId: string;
+    userId: string;
+    reason: string;
+  }): Promise<void> => {
+    const clubRef = doc(db, COLLECTION_NAMES.clubs, clubId);
+    const clubSnap = await getDoc(clubRef);
+    const clubData = clubSnap.data();
+
+    const participantRef = doc(
+      db,
+      COLLECTION_NAMES.clubs,
+      clubId,
+      "participants",
+      userId,
+    );
+
+    // Remove the participant doc and drop any admin role in one atomic write.
+    const batch = writeBatch(db);
+    batch.delete(participantRef);
+    batch.update(clubRef, {
+      clubAdmins: (clubData?.clubAdmins || []).filter(
+        (admin: CompetitionAdmins) => admin.userId !== userId,
+      ),
+    });
+    await batch.commit();
+
+    await sendNotification({
+      ...notificationSchema,
+      createdAt: new Date(),
+      recipientId: userId,
+      senderId: clubData?.clubOwner?.userId,
+      message: `You have been removed from ${clubData?.clubName} for the following reason: ${reason}`,
+      type: notificationTypes.INFORMATION.APP.TYPE,
+      data: { clubId },
+    });
+  };
+
   const fetchUserPendingRequests = async (userId: string) => {
     try {
       const [leaguesSnap, tournamentsSnap] = await Promise.all([
@@ -2613,6 +2731,11 @@ const LeagueProvider = ({ children }: { children: ReactNode }) => {
         requestToJoinClub,
         acceptClubJoinRequest,
         declineClubJoinRequest,
+        updateClub,
+        fetchClubParticipants,
+        assignClubAdmin,
+        revokeClubAdmin,
+        removeClubMember,
         requestToJoinLeague,
         acceptCompetitionJoinRequest,
         declineCompetitionJoinRequest,

--- a/context/LeagueContext.tsx
+++ b/context/LeagueContext.tsx
@@ -502,6 +502,20 @@ const LeagueProvider = ({ children }: { children: ReactNode }) => {
         title: data.clubName ?? "",
       });
 
+      // Record the club's creation in its feed (non-blocking).
+      await clubFeed.clubCreated(data.clubId, {
+        clubName: data.clubName ?? "",
+        actor: data.clubOwner
+          ? {
+              userId: data.clubOwner.userId,
+              username: data.clubOwner.username,
+              firstName: data.clubOwner.firstName,
+              lastName: data.clubOwner.lastName,
+            }
+          : null,
+        image: data.clubImage ?? null,
+      });
+
       AppEventsLogger.logEvent("CreatedClub", {
         club_name: data.clubName,
       });

--- a/context/types/LeagueContextType.ts
+++ b/context/types/LeagueContextType.ts
@@ -182,6 +182,7 @@ export interface LeagueContextType {
     userId: string;
     reason: string;
   }) => Promise<void>;
+  deleteClub: (clubId: string) => Promise<void>;
   acceptClubJoinRequest: (params: {
     senderId: string;
     clubId: string;

--- a/context/types/LeagueContextType.ts
+++ b/context/types/LeagueContextType.ts
@@ -167,6 +167,21 @@ export interface LeagueContextType {
     currentUser: UserProfile;
     ownerId: string;
   }) => Promise<boolean>;
+  updateClub: (club: Club) => Promise<void>;
+  fetchClubParticipants: (clubId: string) => Promise<Player[]>;
+  assignClubAdmin: (params: {
+    clubId: string;
+    user: { userId: string; username: string };
+  }) => Promise<void>;
+  revokeClubAdmin: (params: {
+    clubId: string;
+    userId: string;
+  }) => Promise<void>;
+  removeClubMember: (params: {
+    clubId: string;
+    userId: string;
+    reason: string;
+  }) => Promise<void>;
   acceptClubJoinRequest: (params: {
     senderId: string;
     clubId: string;

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
   "indexes": [],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "participants",
+      "fieldPath": "userId",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    }
+  ]
 }

--- a/functions/src/distributeLeaguePrizes.ts
+++ b/functions/src/distributeLeaguePrizes.ts
@@ -3,7 +3,30 @@ import * as admin from "firebase-admin";
 import moment from "moment-timezone";
 
 import { calculatePrizeAllocation } from "./helpers/calculatePrizeAllocation";
+import { writeClubCompetitionWon } from "./helpers/clubFeed";
 import { League, Game } from "@shared/types";
+
+interface LeagueParticipant {
+  userId?: string;
+  username?: string;
+  displayName?: string;
+  numberOfWins?: number;
+  totalPointDifference?: number;
+  XP?: number;
+}
+
+// 1st place = the same ordering the prize allocation uses (wins → point diff → XP).
+const getLeagueWinner = (
+  participants: LeagueParticipant[],
+): LeagueParticipant | null => {
+  if (!participants.length) return null;
+  return [...participants].sort(
+    (a, b) =>
+      (b.numberOfWins ?? 0) - (a.numberOfWins ?? 0) ||
+      (b.totalPointDifference ?? 0) - (a.totalPointDifference ?? 0) ||
+      (b.XP ?? 0) - (a.XP ?? 0),
+  )[0];
+};
 
 const TIMEZONE = "Europe/London";
 const DISTRIBUTION = [0.4, 0.3, 0.2, 0.1];
@@ -64,6 +87,20 @@ export const distributeLeaguePrizes = onSchedule(
           leagueId,
           leagueName: league.leagueName,
         });
+
+        // If the league belongs to a club, surface the winner in its feed.
+        const winner = getLeagueWinner(
+          (league.leagueParticipants || []) as LeagueParticipant[],
+        );
+        if (winner) {
+          await writeClubCompetitionWon({
+            clubId: (league as { clubId?: string | null }).clubId,
+            competitionId: leagueId,
+            competitionType: "league",
+            name: league.leagueName,
+            winnerName: winner.username ?? winner.displayName ?? "A player",
+          });
+        }
       }
 
       console.log("[prizes] run complete");

--- a/functions/src/distributeTournamentPrizes.ts
+++ b/functions/src/distributeTournamentPrizes.ts
@@ -1,4 +1,5 @@
 import { onSchedule } from "firebase-functions/v2/scheduler";
+import { onDocumentUpdated } from "firebase-functions/v2/firestore";
 import * as admin from "firebase-admin";
 
 import {
@@ -100,6 +101,146 @@ const buildPrizeAllocations = (
   return allocations;
 };
 
+type TournamentSideEffects = {
+  tournament: Tournament;
+  prizeWinners: string[][];
+  participantsById: Map<string | undefined, ScoreboardProfile>;
+  notifications: ReturnType<typeof buildNotification>[];
+};
+
+/**
+ * Distribute one tournament's prizes. The completeness check, XP awards and the
+ * `prizesDistributed` flip all happen inside a single transaction, so the
+ * tournament is atomically "claimed" — a concurrent run (the hourly sweep and
+ * the on-update trigger, or two rapid game updates) can't double-pay. XP and
+ * the flag commit together; notifications + the club feed event are fanned out
+ * afterwards as best-effort side effects.
+ *
+ * No-ops (returns without side effects) when the tournament is missing, not
+ * complete, fixtures aren't generated, or prizes were already distributed.
+ */
+const distributeForTournament = async (
+  db: admin.firestore.Firestore,
+  tournamentId: string,
+): Promise<void> => {
+  const tournamentRef = db.collection("tournaments").doc(tournamentId);
+
+  let sideEffects: TournamentSideEffects | null = null;
+
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(tournamentRef);
+    if (!snap.exists) return;
+
+    const tournament = snap.data() as Tournament;
+
+    if (tournament.prizesDistributed) return;
+    if (!tournament.fixturesGenerated) return;
+
+    const isKnockout = tournament.tournamentMode === "Knockout";
+    const isDoubles = tournament.tournamentType === "Doubles";
+    const isComplete = isKnockout
+      ? isKnockoutComplete(tournament.fixtures)
+      : isRoundRobinComplete(tournament, tournamentId);
+
+    if (!isComplete) return;
+
+    const prizePool = calculateTournamentPrizePool(
+      tournament.numberOfGames!,
+      tournament.tournamentType as "Singles" | "Doubles",
+    );
+
+    const prizeWinners = getPrizeWinnerIds(tournament);
+    const allocations = buildPrizeAllocations(
+      prizeWinners,
+      prizePool,
+      isDoubles,
+    );
+
+    // Build player lookup once — was O(n) per player, now O(1).
+    const participantsById = new Map(
+      tournament.tournamentParticipants.map((p: ScoreboardProfile) => [
+        p.userId,
+        p,
+      ]),
+    );
+
+    const notifications: ReturnType<typeof buildNotification>[] = [];
+
+    for (const {
+      userId,
+      prizeXP,
+      placementKey,
+      placementIndex,
+    } of allocations) {
+      const playerProfile = participantsById.get(userId);
+      if (!playerProfile) {
+        console.error(`Player profile not found for player ${userId}`);
+        continue;
+      }
+
+      tx.update(db.collection("users").doc(userId), {
+        "profileDetail.XP": admin.firestore.FieldValue.increment(prizeXP),
+        [`profileDetail.tournamentStats.${placementKey}`]:
+          admin.firestore.FieldValue.increment(1),
+      });
+
+      notifications.push(
+        buildNotification({
+          userId,
+          tournamentId,
+          tournamentName: tournament.tournamentName,
+          prizeXP,
+          placementIndex,
+          isDoubles,
+        }),
+      );
+
+      console.log(
+        `+${prizeXP} XP -> user ${userId} (${playerProfile.username}) (${placementKey})`,
+      );
+    }
+
+    // Claim + mark distributed in the SAME atomic write as the XP awards.
+    tx.update(tournamentRef, {
+      prizesDistributed: true,
+      prizeDistributionDate: admin.firestore.FieldValue.serverTimestamp(),
+    });
+
+    sideEffects = {
+      tournament,
+      prizeWinners,
+      participantsById,
+      notifications,
+    };
+  });
+
+  // `null` means nothing was claimed this run (not ready / already done).
+  const effects: TournamentSideEffects | null = sideEffects;
+  if (!effects) return;
+
+  await Promise.all(effects.notifications.map((n) => sendNotification(n)));
+
+  // If the tournament belongs to a club, surface the winner in its feed.
+  const winnerIds = effects.prizeWinners[0] ?? [];
+  if (winnerIds.length > 0) {
+    const winnerName = winnerIds
+      .map((id) => effects.participantsById.get(id)?.username ?? "A player")
+      .join(" / ");
+    await writeClubCompetitionWon({
+      clubId: (effects.tournament as { clubId?: string | null }).clubId,
+      competitionId: tournamentId,
+      competitionType: "tournament",
+      name: effects.tournament.tournamentName,
+      winnerName,
+    });
+  }
+
+  console.log(`Prizes distributed for tournament ${tournamentId}`);
+};
+
+// Hourly safety net: catches any completion the on-update trigger missed
+// (manual data edits, dropped events, etc.). Shares distributeForTournament,
+// whose atomic claim makes running alongside the trigger safe.
 const distributeTournamentPrizes = onSchedule("every 1 hours", async () => {
   const db = admin.firestore();
   try {
@@ -109,113 +250,7 @@ const distributeTournamentPrizes = onSchedule("every 1 hours", async () => {
       .get();
 
     for (const tournamentDoc of snap.docs) {
-      const tournament = tournamentDoc.data() as Tournament;
-      const tournamentId = tournamentDoc.id;
-
-      if (tournament.prizesDistributed) {
-        console.log(`[prizes] ${tournamentId} already distributed`);
-        continue;
-      }
-      if (!tournament.fixturesGenerated) {
-        console.log(`[prizes] ${tournamentId} fixtures not generated yet`);
-        continue;
-      }
-
-      const isKnockout = tournament.tournamentMode === "Knockout";
-      const isDoubles = tournament.tournamentType === "Doubles";
-      const isComplete = isKnockout
-        ? isKnockoutComplete(tournament.fixtures)
-        : isRoundRobinComplete(tournament, tournamentId);
-
-      if (!isComplete) {
-        if (isKnockout)
-          console.log(`[prizes] ${tournamentId} knockout not complete yet`);
-        continue;
-      }
-
-      const prizePool = calculateTournamentPrizePool(
-        tournament.numberOfGames!,
-        tournament.tournamentType as "Singles" | "Doubles",
-      );
-
-      const prizeWinners = getPrizeWinnerIds(tournament);
-      const allocations = buildPrizeAllocations(
-        prizeWinners,
-        prizePool,
-        isDoubles,
-      );
-
-      // Build player lookup once — was O(n) per player, now O(1).
-      const participantsById = new Map(
-        tournament.tournamentParticipants.map((p: ScoreboardProfile) => [
-          p.userId,
-          p,
-        ]),
-      );
-
-      // Batch user writes + fan out notifications in parallel.
-      const userWritesBatch = db.batch();
-      const notificationsToSend: Array<ReturnType<typeof buildNotification>> =
-        [];
-
-      for (const {
-        userId,
-        prizeXP,
-        placementKey,
-        placementIndex,
-      } of allocations) {
-        const playerProfile = participantsById.get(userId);
-        if (!playerProfile) {
-          console.error(`Player profile not found for player ${userId}`);
-          continue;
-        }
-
-        userWritesBatch.update(db.collection("users").doc(userId), {
-          "profileDetail.XP": admin.firestore.FieldValue.increment(prizeXP),
-          [`profileDetail.tournamentStats.${placementKey}`]:
-            admin.firestore.FieldValue.increment(1),
-        });
-
-        notificationsToSend.push(
-          buildNotification({
-            userId,
-            tournamentId,
-            tournamentName: tournament.tournamentName,
-            prizeXP,
-            placementIndex,
-            isDoubles,
-          }),
-        );
-
-        console.log(
-          `+${prizeXP} XP -> user ${userId} (${playerProfile.username}) (${placementKey})`,
-        );
-      }
-
-      userWritesBatch.update(db.collection("tournaments").doc(tournamentId), {
-        prizesDistributed: true,
-        prizeDistributionDate: admin.firestore.FieldValue.serverTimestamp(),
-      });
-
-      await userWritesBatch.commit();
-      await Promise.all(notificationsToSend.map((n) => sendNotification(n)));
-
-      // If the tournament belongs to a club, surface the winner in its feed.
-      const winnerIds = prizeWinners[0] ?? [];
-      if (winnerIds.length > 0) {
-        const winnerName = winnerIds
-          .map((id) => participantsById.get(id)?.username ?? "A player")
-          .join(" / ");
-        await writeClubCompetitionWon({
-          clubId: (tournament as { clubId?: string | null }).clubId,
-          competitionId: tournamentId,
-          competitionType: "tournament",
-          name: tournament.tournamentName,
-          winnerName,
-        });
-      }
-
-      console.log(`Prizes distributed for tournament ${tournamentId}`);
+      await distributeForTournament(db, tournamentDoc.id);
     }
 
     console.log("[prizes] run complete");
@@ -223,6 +258,28 @@ const distributeTournamentPrizes = onSchedule("every 1 hours", async () => {
     console.error("[prizes] error:", err);
   }
 });
+
+// Instant path: fires the moment a tournament doc changes (e.g. the last game
+// is approved and gamesCompleted is incremented), so prizes pay out without
+// waiting for the hourly sweep.
+const distributeTournamentPrizesOnComplete = onDocumentUpdated(
+  "tournaments/{tournamentId}",
+  async (event) => {
+    const after = event.data?.after.data();
+    // Skip if the doc was deleted or prizes are already (being) distributed.
+    if (!after || after.prizesDistributed !== false) return;
+
+    const db = admin.firestore();
+    try {
+      await distributeForTournament(db, event.params.tournamentId);
+    } catch (err) {
+      console.error(
+        `[prizes] on-complete trigger error for ${event.params.tournamentId}:`,
+        err,
+      );
+    }
+  },
+);
 
 const buildNotification = ({
   userId,
@@ -251,4 +308,4 @@ const buildNotification = ({
   response: "",
 });
 
-export { distributeTournamentPrizes };
+export { distributeTournamentPrizes, distributeTournamentPrizesOnComplete };

--- a/functions/src/distributeTournamentPrizes.ts
+++ b/functions/src/distributeTournamentPrizes.ts
@@ -12,6 +12,7 @@ import {
 } from "@shared/helpers/getRankInCompetition";
 import { ScoreboardProfile, Tournament } from "@shared/types";
 import { sendNotification } from "./helpers/sendNotification";
+import { writeClubCompetitionWon } from "./helpers/clubFeed";
 import { notificationTypes } from "@shared";
 
 const DISTRIBUTION = [0.4, 0.3, 0.2, 0.1];
@@ -198,6 +199,21 @@ const distributeTournamentPrizes = onSchedule("every 1 hours", async () => {
 
       await userWritesBatch.commit();
       await Promise.all(notificationsToSend.map((n) => sendNotification(n)));
+
+      // If the tournament belongs to a club, surface the winner in its feed.
+      const winnerIds = prizeWinners[0] ?? [];
+      if (winnerIds.length > 0) {
+        const winnerName = winnerIds
+          .map((id) => participantsById.get(id)?.username ?? "A player")
+          .join(" / ");
+        await writeClubCompetitionWon({
+          clubId: (tournament as { clubId?: string | null }).clubId,
+          competitionId: tournamentId,
+          competitionType: "tournament",
+          name: tournament.tournamentName,
+          winnerName,
+        });
+      }
 
       console.log(`Prizes distributed for tournament ${tournamentId}`);
     }

--- a/functions/src/helpers/clubFeed.ts
+++ b/functions/src/helpers/clubFeed.ts
@@ -1,0 +1,43 @@
+import * as admin from "firebase-admin";
+
+/**
+ * Admin-SDK counterpart of the client `clubFeed` helper. Cloud functions run
+ * with firebase-admin (a different Firestore handle to the client SDK), so the
+ * feed-writing logic is duplicated here rather than imported from the app.
+ *
+ * Best-effort: a feed write must never fail prize distribution, so errors are
+ * swallowed.
+ */
+export const writeClubCompetitionWon = async ({
+  clubId,
+  competitionId,
+  competitionType,
+  name,
+  winnerName,
+}: {
+  clubId?: string | null;
+  competitionId: string;
+  competitionType: "league" | "tournament";
+  name: string;
+  winnerName: string;
+}): Promise<void> => {
+  if (!clubId) return;
+  try {
+    const db = admin.firestore();
+    await db
+      .collection("clubs")
+      .doc(clubId)
+      .collection("feed")
+      .doc()
+      .set({
+        type: "competition_won",
+        title: "Competition winner",
+        message: `${winnerName} won the ${competitionType} "${name}"`,
+        icon: "trophy-outline",
+        data: { competitionId, competitionType },
+        createdAt: new Date(),
+      });
+  } catch (error) {
+    console.error("writeClubCompetitionWon error:", error);
+  }
+};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,7 +2,10 @@ import * as admin from "firebase-admin";
 import { autoApproveLeagueGames } from "./autoApproveLeagueGames";
 import { distributeLeaguePrizes } from "./distributeLeaguePrizes";
 import { broadcastNotification } from "./broadcastNotification";
-import { distributeTournamentPrizes } from "./distributeTournamentPrizes";
+import {
+  distributeTournamentPrizes,
+  distributeTournamentPrizesOnComplete,
+} from "./distributeTournamentPrizes";
 import { ogPreview } from "./ogPreview";
 import { autoApproveTournamentGames } from "./autoApproveTournamentGames";
 import { notifyOwnersToInvitePlayers } from "./notifyOwnersToInvitePlayers";
@@ -21,6 +24,7 @@ export {
   distributeLeaguePrizes,
   broadcastNotification,
   distributeTournamentPrizes,
+  distributeTournamentPrizesOnComplete,
   ogPreview,
   autoApproveLeagueGames,
   autoApproveTournamentGames,

--- a/helpers/clubFeed.ts
+++ b/helpers/clubFeed.ts
@@ -35,6 +35,23 @@ export const addClubFeedEvent = async (
  * live here. Add a new builder per future event type.
  */
 export const clubFeed = {
+  clubCreated: (
+    clubId: string,
+    p: {
+      clubName: string;
+      actor?: ClubFeedActor | null;
+      image?: string | null;
+    },
+  ) =>
+    addClubFeedEvent(clubId, {
+      type: "club_created",
+      title: "Club created",
+      message: `${p.actor?.firstName ?? p.actor?.username ?? "The owner"} created the club "${p.clubName}"`,
+      actor: p.actor ?? null,
+      thumbnail: p.image ?? null,
+      icon: "flag-outline",
+    }),
+
   playerJoined: (clubId: string, actor: ClubFeedActor) =>
     addClubFeedEvent(clubId, {
       type: "player_joined",

--- a/helpers/clubPlayerStats.ts
+++ b/helpers/clubPlayerStats.ts
@@ -1,4 +1,12 @@
-import { collection, getDocs, getDoc, doc, query, where } from "firebase/firestore";
+import {
+  collection,
+  collectionGroup,
+  getDocs,
+  getDoc,
+  doc,
+  query,
+  where,
+} from "firebase/firestore";
 
 import { db } from "../services/firebase.config";
 import { COLLECTION_NAMES } from "@shared";
@@ -160,6 +168,152 @@ export const getClubAggregatedPlayers = async ({
     leagues: leaguesSnap.docs.map((d) => d.data() as RawCompetitionData),
     tournaments: tournamentsSnap.docs.map((d) => d.data() as RawCompetitionData),
   });
+};
+
+/**
+ * All clubs a user belongs to, resolved from the `participants` subcollections
+ * directly (owner, admins and members are all stored there). This is the source
+ * of truth for membership — unlike deriving clubs from the competitions a user
+ * plays in, it also surfaces clubs the user has joined but has no games in yet.
+ *
+ * Uses a collection-group query, which needs a COLLECTION_GROUP single-field
+ * index on `participants.userId` (see firestore.indexes.json). If that index
+ * isn't deployed yet the query throws — we swallow it and return [] so callers
+ * can fall back to their competition-derived list instead of erroring.
+ */
+export const getMemberClubIds = async (userId: string): Promise<string[]> => {
+  if (!userId) return [];
+  try {
+    const snap = await getDocs(
+      query(collectionGroup(db, "participants"), where("userId", "==", userId)),
+    );
+    const ids = snap.docs
+      // participant doc → participants collection → club doc → clubs collection
+      .filter((d) => d.ref.parent.parent?.parent.id === COLLECTION_NAMES.clubs)
+      .map((d) => d.ref.parent.parent?.id)
+      .filter((id): id is string => !!id);
+    return Array.from(new Set(ids));
+  } catch (error) {
+    console.error("getMemberClubIds failed (participants index missing?):", error);
+    return [];
+  }
+};
+
+export interface ClubTeamStat {
+  teamKey: string;
+  team: string[];
+  numberOfWins: number;
+  totalPointDifference: number;
+}
+
+export interface ClubSummaryStats {
+  /** Highest-ranked player across the club's competitions (null if no games). */
+  topPlayer: ClubPlayerStat | null;
+  /** Highest-ranked team across the club's competitions (null if no games). */
+  topTeam: ClubTeamStat | null;
+  /** Approved games played across all of the club's leagues + tournaments. */
+  totalGamesPlayed: number;
+}
+
+const isApprovedGame = (game: unknown): boolean =>
+  String((game as { approvalStatus?: string })?.approvalStatus ?? "")
+    .toLowerCase() === "approved";
+
+// League games live on `games`; tournament games are nested in `fixtures[].games`.
+const countApprovedGames = (data: {
+  games?: unknown[];
+  fixtures?: { games?: unknown[] }[];
+}): number => {
+  const direct = Array.isArray(data.games) ? data.games : [];
+  const fixtureGames = Array.isArray(data.fixtures)
+    ? data.fixtures.flatMap((f) => (Array.isArray(f?.games) ? f.games : []))
+    : [];
+  return [...direct, ...fixtureGames].filter(isApprovedGame).length;
+};
+
+/**
+ * Club-level headline stats for the Summary tab: the top player, top team, and
+ * total games played, aggregated across every league + tournament the club
+ * manages. Reuses the same player accumulation as the performance/activity tabs.
+ */
+export const getClubSummaryStats = async ({
+  clubId,
+}: {
+  clubId: string;
+}): Promise<ClubSummaryStats> => {
+  const clubFilter = where("clubId", "==", clubId);
+
+  const [membersSnap, leaguesSnap, tournamentsSnap] = await Promise.all([
+    getDocs(collection(db, COLLECTION_NAMES.clubs, clubId, "participants")),
+    getDocs(query(collection(db, COLLECTION_NAMES.leagues), clubFilter)),
+    getDocs(query(collection(db, COLLECTION_NAMES.tournaments), clubFilter)),
+  ]);
+
+  const leagues = leaguesSnap.docs.map((d) => d.data() as RawCompetitionData);
+  const tournaments = tournamentsSnap.docs.map(
+    (d) => d.data() as RawCompetitionData,
+  );
+
+  // Top player — accumulate members across all comps, rank by wins → point diff.
+  const players = buildClubPlayerMap({
+    members: membersSnap.docs.map((d) => d.data() as RawMember),
+    leagues,
+    tournaments,
+  }).sort(
+    (a, b) =>
+      b.numberOfWins - a.numberOfWins ||
+      b.totalPointDifference - a.totalPointDifference,
+  );
+  const topPlayer = players.find((p) => p.numberOfWins > 0) ?? null;
+
+  // Top team — merge team stats keyed by teamKey across all comps.
+  const teamMap = new Map<string, ClubTeamStat>();
+  const mergeTeams = (
+    raw: { leagueTeams?: unknown[]; tournamentTeams?: unknown[]; teams?: unknown[] },
+  ) => {
+    const teams = (raw.leagueTeams ??
+      raw.tournamentTeams ??
+      raw.teams ??
+      []) as {
+      teamKey?: string;
+      team?: string[];
+      numberOfWins?: number;
+      totalPointDifference?: number;
+    }[];
+    teams.forEach((t) => {
+      if (!t.teamKey || !Array.isArray(t.team)) return;
+      const existing = teamMap.get(t.teamKey);
+      if (!existing) {
+        teamMap.set(t.teamKey, {
+          teamKey: t.teamKey,
+          team: t.team,
+          numberOfWins: t.numberOfWins ?? 0,
+          totalPointDifference: t.totalPointDifference ?? 0,
+        });
+      } else {
+        existing.numberOfWins += t.numberOfWins ?? 0;
+        existing.totalPointDifference += t.totalPointDifference ?? 0;
+      }
+    });
+  };
+  [...leaguesSnap.docs, ...tournamentsSnap.docs].forEach((d) =>
+    mergeTeams(d.data() as Record<string, unknown>),
+  );
+  const topTeam =
+    Array.from(teamMap.values())
+      .sort(
+        (a, b) =>
+          b.numberOfWins - a.numberOfWins ||
+          b.totalPointDifference - a.totalPointDifference,
+      )
+      .find((t) => t.numberOfWins > 0) ?? null;
+
+  const totalGamesPlayed = [...leagues, ...tournaments].reduce(
+    (sum, data) => sum + countApprovedGames(data as never),
+    0,
+  );
+
+  return { topPlayer, topTeam, totalGamesPlayed };
 };
 
 export interface ClubActivity {

--- a/navigation/tabs.js
+++ b/navigation/tabs.js
@@ -34,6 +34,9 @@ import TournamentSettings from "../screens/Home/Tournaments/TournamentSettings";
 import ClubSettings from "../screens/Home/Clubs/ClubSettings";
 import ClubPendingRequests from "../screens/Home/Clubs/ClubPendingRequests";
 import ClubPendingInvites from "../screens/Home/Clubs/ClubPendingInvites";
+import EditClub from "../screens/Home/Clubs/EditClub";
+import ClubAssignAdmin from "../screens/Home/Settings/ClubAssignAdmin";
+import ClubRemoveMembers from "../screens/Home/Settings/ClubRemoveMembers";
 import BulkFixturesPublisher from "../screens/Home/Tournaments/BulkFixturesPublisher";
 import EditTournament from "../screens/Home/Tournaments/EditTournament";
 import Tournaments from "../screens/Home/Tournaments/Tournaments";
@@ -77,6 +80,9 @@ const HomeStack = () => {
         component={ClubPendingRequests}
       />
       <Stack.Screen name="ClubPendingInvites" component={ClubPendingInvites} />
+      <Stack.Screen name="EditClub" component={EditClub} />
+      <Stack.Screen name="ClubAssignAdmin" component={ClubAssignAdmin} />
+      <Stack.Screen name="ClubRemoveMembers" component={ClubRemoveMembers} />
       <Stack.Screen name="UserProfile" component={UserProfile} />
       <Stack.Screen name="UserFeedback" component={UserFeedback} />
       <Stack.Screen name="ProfileMenu" component={ProfileMenu} />
@@ -123,6 +129,9 @@ const ProfileStack = () => {
         component={ClubPendingRequests}
       />
       <Stack.Screen name="ClubPendingInvites" component={ClubPendingInvites} />
+      <Stack.Screen name="EditClub" component={EditClub} />
+      <Stack.Screen name="ClubAssignAdmin" component={ClubAssignAdmin} />
+      <Stack.Screen name="ClubRemoveMembers" component={ClubRemoveMembers} />
       <Stack.Screen name="EditLeague" component={EditLeague} />
       <Stack.Screen name="LeagueSettings" component={LeagueSettings} />
       <Stack.Screen name="PendingInvites" component={PendingInvites} />
@@ -172,6 +181,9 @@ const ChatsStack = () => {
         component={ClubPendingRequests}
       />
       <Stack.Screen name="ClubPendingInvites" component={ClubPendingInvites} />
+      <Stack.Screen name="EditClub" component={EditClub} />
+      <Stack.Screen name="ClubAssignAdmin" component={ClubAssignAdmin} />
+      <Stack.Screen name="ClubRemoveMembers" component={ClubRemoveMembers} />
       <Stack.Screen name="EditLeague" component={EditLeague} />
       <Stack.Screen name="LeagueSettings" component={LeagueSettings} />
       <Stack.Screen name="PendingInvites" component={PendingInvites} />
@@ -221,6 +233,9 @@ const CompetitionsStack = () => {
         component={ClubPendingRequests}
       />
       <Stack.Screen name="ClubPendingInvites" component={ClubPendingInvites} />
+      <Stack.Screen name="EditClub" component={EditClub} />
+      <Stack.Screen name="ClubAssignAdmin" component={ClubAssignAdmin} />
+      <Stack.Screen name="ClubRemoveMembers" component={ClubRemoveMembers} />
       <Stack.Screen name="EditLeague" component={EditLeague} />
       <Stack.Screen name="LeagueSettings" component={LeagueSettings} />
       <Stack.Screen name="PendingInvites" component={PendingInvites} />

--- a/screens/Home/Clubs/Club.tsx
+++ b/screens/Home/Clubs/Club.tsx
@@ -28,6 +28,7 @@ import { COLLECTION_NAMES } from "@shared";
 import { db } from "../../../services/firebase.config";
 import type { Club } from "@shared/types";
 
+import ClubSummary from "./tabs/ClubSummary";
 import ClubFeed from "./tabs/ClubFeed";
 import ClubPerformance from "./tabs/ClubPerformance";
 import ClubLeagues from "./tabs/ClubLeagues";
@@ -37,6 +38,7 @@ import UserRoleTag from "../../../components/UserRoleTag";
 const { width: screenWidth } = Dimensions.get("window");
 
 const PRIMARY_TABS = [
+  "Summary",
   "Feed",
   "Club Performance",
   "Leagues",
@@ -80,7 +82,7 @@ const ClubScreen: React.FC = () => {
   const [isParticipant, setIsParticipant] = useState(false);
   const [isJoinRequestSending, setIsJoinRequestSending] = useState(false);
   const [selectedTab, setSelectedTab] = useState<PrimaryTab>(
-    primaryTab ?? "Feed",
+    primaryTab ?? "Summary",
   );
 
   const isOwner = currentUser?.userId === clubById?.clubOwner?.userId;
@@ -131,19 +133,17 @@ const ClubScreen: React.FC = () => {
             setMemberCount(0);
           } else {
             setClubNotFound(false);
-            // Only fetch participants subcollection on first load —
-            // it's expensive and the membership data is stable enough
-            // for a background refocus (e.g. returning from a league page).
-            if (isFirstLoad) {
-              const snap = await getDocs(
-                collection(db, COLLECTION_NAMES.clubs, clubId, "participants"),
+            // Re-fetch participants on every focus so membership (member count
+            // and the join CTA) reflects a request that was accepted — or a
+            // removal — while this screen stayed mounted in the stack.
+            const snap = await getDocs(
+              collection(db, COLLECTION_NAMES.clubs, clubId, "participants"),
+            );
+            if (!cancelled) {
+              setMemberCount(snap.size);
+              setIsParticipant(
+                snap.docs.some((doc) => doc.id === currentUser?.userId),
               );
-              if (!cancelled) {
-                setMemberCount(snap.size);
-                setIsParticipant(
-                  snap.docs.some((doc) => doc.id === currentUser?.userId),
-                );
-              }
             }
           }
         } catch (e) {
@@ -189,6 +189,8 @@ const ClubScreen: React.FC = () => {
 
   const renderPrimaryContent = () => {
     switch (selectedTab) {
+      case "Summary":
+        return <ClubSummary clubId={clubId} club={clubById} />;
       case "Feed":
         return <ClubFeed clubId={clubId} />;
       case "Club Performance":

--- a/screens/Home/Clubs/ClubSettings.js
+++ b/screens/Home/Clubs/ClubSettings.js
@@ -20,7 +20,7 @@ const ClubSettings = () => {
   const route = useRoute();
   const { clubId, club } = route.params;
   const { currentUser } = useContext(UserContext);
-  const { deleteCompetition } = useContext(LeagueContext);
+  const { deleteClub } = useContext(LeagueContext);
   const navigation = useNavigation();
   const [deleting, setDeleting] = useState(false);
   const [passwordModalVisible, setPasswordModalVisible] = useState(false);
@@ -104,7 +104,7 @@ const ClubSettings = () => {
       // Verifies password without relying on auth.currentUser hydration
       await signInWithEmailAndPassword(auth, currentUser.email, password);
 
-      await deleteCompetition(COLLECTION_NAMES.clubs, clubId);
+      await deleteClub(clubId);
       setPasswordModalVisible(false);
       navigation.reset({ index: 0, routes: [{ name: "Home" }] });
     } catch (error) {

--- a/screens/Home/Clubs/ClubSettings.js
+++ b/screens/Home/Clubs/ClubSettings.js
@@ -1,15 +1,31 @@
-import React, { useContext } from "react";
-import { View, StyleSheet } from "react-native";
+import React, { useContext, useState } from "react";
+import {
+  View,
+  StyleSheet,
+  Modal,
+  Alert,
+  ActivityIndicator,
+} from "react-native";
 import styled from "styled-components/native";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import { BlurView } from "expo-blur";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { UserContext } from "../../../context/UserContext";
+import { LeagueContext } from "../../../context/LeagueContext";
+import { COLLECTION_NAMES } from "@shared";
+import { signInWithEmailAndPassword } from "firebase/auth";
+import { auth } from "../../../services/firebase.config";
 
 const ClubSettings = () => {
   const route = useRoute();
   const { clubId, club } = route.params;
   const { currentUser } = useContext(UserContext);
+  const { deleteCompetition } = useContext(LeagueContext);
   const navigation = useNavigation();
+  const [deleting, setDeleting] = useState(false);
+  const [passwordModalVisible, setPasswordModalVisible] = useState(false);
+  const [password, setPassword] = useState("");
+  const [passwordError, setPasswordError] = useState("");
 
   const isOwner = club?.clubOwner?.userId === currentUser?.userId;
 
@@ -51,6 +67,61 @@ const ClubSettings = () => {
           option.action !== "DeleteClub",
       );
 
+  const handleDeletePress = () => {
+    Alert.alert(
+      "Delete Club",
+      `Are you sure you want to delete "${club?.clubName}"? This action cannot be undone.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: () => {
+            setPassword("");
+            setPasswordError("");
+            setPasswordModalVisible(true);
+          },
+        },
+      ],
+    );
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!password.trim()) {
+      setPasswordError("Please enter your password");
+      return;
+    }
+
+    if (!currentUser?.email) {
+      setPasswordError("Unable to verify your account.");
+      return;
+    }
+
+    try {
+      setDeleting(true);
+      setPasswordError("");
+
+      // Verifies password without relying on auth.currentUser hydration
+      await signInWithEmailAndPassword(auth, currentUser.email, password);
+
+      await deleteCompetition(COLLECTION_NAMES.clubs, clubId);
+      setPasswordModalVisible(false);
+      navigation.reset({ index: 0, routes: [{ name: "Home" }] });
+    } catch (error) {
+      if (
+        error.code === "auth/wrong-password" ||
+        error.code === "auth/invalid-credential"
+      ) {
+        setPasswordError("Incorrect password. Please try again.");
+      } else {
+        Alert.alert("Error", "Failed to delete club. Please try again.");
+        console.error("Delete club error:", error);
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   const handlePress = (action) => {
     if (action === "ClubPendingRequests") {
       navigation.navigate("ClubPendingRequests", { clubId });
@@ -60,12 +131,67 @@ const ClubSettings = () => {
       navigation.navigate("ClubPendingInvites", { clubId });
       return;
     }
-    // Other actions not yet implemented
-    console.log(`[ClubSettings] Pressed: ${action}`, { clubId, club });
+    if (action === "DeleteClub") {
+      handleDeletePress();
+      return;
+    }
+    navigation.navigate(action, {
+      clubId,
+      club,
+      collectionName: COLLECTION_NAMES.clubs,
+    });
   };
 
   return (
     <Container>
+      <Modal
+        transparent
+        animationType="fade"
+        visible={passwordModalVisible}
+        onRequestClose={() => !deleting && setPasswordModalVisible(false)}
+      >
+        <BlurView style={styles.blurContainer} intensity={50} tint="dark">
+          <PasswordModal>
+            <PasswordTitle>Confirm Deletion</PasswordTitle>
+            <PasswordSubtitle>
+              Enter your password to permanently delete this club
+            </PasswordSubtitle>
+            <PasswordInput
+              placeholder="Enter password"
+              placeholderTextColor="#666"
+              secureTextEntry
+              value={password}
+              onChangeText={(text) => {
+                setPassword(text);
+                setPasswordError("");
+              }}
+              autoFocus
+            />
+            {passwordError ? (
+              <PasswordError>{passwordError}</PasswordError>
+            ) : null}
+            <ModalButtonRow>
+              <ModalCancelButton
+                onPress={() => setPasswordModalVisible(false)}
+                disabled={deleting}
+              >
+                <ModalCancelText>Cancel</ModalCancelText>
+              </ModalCancelButton>
+              <ModalDeleteButton
+                onPress={handleConfirmDelete}
+                disabled={deleting}
+              >
+                {deleting ? (
+                  <ActivityIndicator size="small" color="white" />
+                ) : (
+                  <ModalDeleteText>Delete</ModalDeleteText>
+                )}
+              </ModalDeleteButton>
+            </ModalButtonRow>
+          </PasswordModal>
+        </BlurView>
+      </Modal>
+
       <Header>
         <BackButton onPress={() => navigation.goBack()}>
           <Ionicons name="arrow-back" size={24} color="white" />
@@ -97,6 +223,14 @@ const ClubSettings = () => {
     </Container>
   );
 };
+
+const styles = StyleSheet.create({
+  blurContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});
 
 const Container = styled.View({
   flex: 1,
@@ -144,6 +278,80 @@ const LeftContainer = styled.View({
 const MenuText = styled.Text({
   color: "white",
   fontSize: 16,
+});
+
+const PasswordModal = styled.View({
+  backgroundColor: "rgb(3, 16, 31)",
+  borderRadius: 16,
+  padding: 24,
+  width: "85%",
+  borderWidth: 1,
+  borderColor: "rgba(255, 59, 48, 0.3)",
+});
+
+const PasswordTitle = styled.Text({
+  color: "white",
+  fontSize: 18,
+  fontWeight: "bold",
+  marginBottom: 8,
+});
+
+const PasswordSubtitle = styled.Text({
+  color: "#aaa",
+  fontSize: 14,
+  marginBottom: 20,
+  lineHeight: 20,
+});
+
+const PasswordInput = styled.TextInput({
+  backgroundColor: "rgba(255, 255, 255, 0.08)",
+  borderRadius: 8,
+  padding: 12,
+  color: "white",
+  fontSize: 16,
+  borderWidth: 1,
+  borderColor: "rgba(255, 255, 255, 0.15)",
+  marginBottom: 8,
+});
+
+const PasswordError = styled.Text({
+  color: "#FF3B30",
+  fontSize: 13,
+  marginBottom: 12,
+});
+
+const ModalButtonRow = styled.View({
+  flexDirection: "row",
+  gap: 12,
+  marginTop: 20,
+});
+
+const ModalCancelButton = styled.TouchableOpacity({
+  flex: 1,
+  padding: 14,
+  borderRadius: 8,
+  backgroundColor: "rgba(255, 255, 255, 0.08)",
+  alignItems: "center",
+});
+
+const ModalCancelText = styled.Text({
+  color: "white",
+  fontSize: 16,
+  fontWeight: "500",
+});
+
+const ModalDeleteButton = styled.TouchableOpacity({
+  flex: 1,
+  padding: 14,
+  borderRadius: 8,
+  backgroundColor: "#FF3B30",
+  alignItems: "center",
+});
+
+const ModalDeleteText = styled.Text({
+  color: "white",
+  fontSize: 16,
+  fontWeight: "bold",
 });
 
 export default ClubSettings;

--- a/screens/Home/Clubs/EditClub.js
+++ b/screens/Home/Clubs/EditClub.js
@@ -1,0 +1,358 @@
+import React, { useContext, useState, useMemo, useEffect } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  SafeAreaView,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+
+import { LeagueContext } from "../../../context/LeagueContext";
+import * as ImagePicker from "expo-image-picker";
+import * as ImageManipulator from "expo-image-manipulator";
+import styled from "styled-components/native";
+import { AntDesign } from "@expo/vector-icons";
+import { useForm, Controller } from "react-hook-form";
+import { uploadClubImage } from "../../../utils/UploadClubImageToFirebase";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import Popup from "../../../components/popup/Popup";
+import { PopupContext } from "../../../context/PopupContext";
+import { File } from "expo-file-system";
+
+const EditClub = () => {
+  const route = useRoute();
+  const { clubId, club } = route.params;
+
+  const { updateClub, fetchClubById } = useContext(LeagueContext);
+  const navigation = useNavigation();
+
+  const [loading, setLoading] = useState(true);
+  const [selectedImage, setSelectedImage] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    handleShowPopup,
+    setPopupMessage,
+    popupMessage,
+    setShowPopup,
+    showPopup,
+  } = useContext(PopupContext);
+
+  const handleClosePopup = () => {
+    setShowPopup(false);
+    setPopupMessage("");
+
+    navigation.goBack();
+  };
+
+  useEffect(() => {
+    const loadClub = async () => {
+      if (!club || club.clubId !== clubId) {
+        await fetchClubById(clubId);
+      }
+      setSelectedImage(club?.clubImage || null);
+      setLoading(false);
+    };
+    loadClub();
+  }, [clubId]);
+
+  // Setup React Hook Form
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isDirty },
+    watch,
+  } = useForm({
+    defaultValues: {
+      clubImage: club.clubImage || "",
+      clubDescription: club.clubDescription || "",
+    },
+  });
+
+  // Watch form values for change detection
+  const formValues = watch();
+
+  const hasChanges = useMemo(() => {
+    if (!club) return false;
+    const imageChanged = selectedImage !== club.clubImage;
+    const descriptionChanged =
+      formValues.clubDescription !== club.clubDescription;
+    return imageChanged || descriptionChanged || isDirty;
+  }, [selectedImage, club, formValues, isDirty]);
+
+  const handleImagePick = async () => {
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        allowsEditing: true,
+        quality: 1,
+        aspect: [1, 1],
+      });
+
+      if (!result.canceled && result.assets.length > 0) {
+        const asset = result.assets[0];
+        const pickedUri = asset.uri;
+
+        // Check file size (5MB = 5 * 1024 * 1024 bytes)
+        const MAX_SIZE = 5 * 1024 * 1024; // 5MB in bytes
+
+        // Get file info to check size
+        const fileInfo = new File(pickedUri);
+
+        if (fileInfo.size && fileInfo.size > MAX_SIZE) {
+          Alert.alert(
+            "File Too Large",
+            `Image size is ${(fileInfo.size / (1024 * 1024)).toFixed(
+              2,
+            )}MB. Please select an image smaller than 5MB.`,
+            [{ text: "OK" }],
+          );
+          return;
+        }
+
+        const cropped = await ImageManipulator.manipulateAsync(
+          pickedUri,
+          [{ resize: { width: 600 } }],
+          { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG },
+        );
+
+        // Optional: Log the final image size
+        const croppedInfo = new File(cropped.uri);
+        console.log(
+          `Final image size: ${(croppedInfo.size / 1024).toFixed(1)}KB`,
+        );
+
+        setSelectedImage(cropped.uri);
+      }
+    } catch (error) {
+      console.error("Image picker error:", error);
+      Alert.alert("Error", "Unable to pick image.");
+    }
+  };
+
+  const onSubmit = async (data) => {
+    if (!hasChanges) return;
+
+    setIsSubmitting(true);
+    try {
+      let updatedImage = selectedImage;
+      if (selectedImage && selectedImage !== club.clubImage) {
+        updatedImage = await uploadClubImage(selectedImage, club.clubId);
+      }
+
+      const updatedClub = {
+        ...club,
+        clubDescription: data.clubDescription,
+        clubImage: updatedImage || club.clubImage,
+      };
+
+      await updateClub(updatedClub);
+      handleShowPopup("Club updated!");
+    } catch (err) {
+      console.error("Update error:", err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (loading || !club) {
+    return (
+      <SafeAreaWrapper>
+        <ScrollContainer
+          contentContainerStyle={{
+            alignItems: "center",
+            justifyContent: "center",
+            flex: 1,
+          }}
+        >
+          <ActivityIndicator size="large" color="#00A2FF" />
+        </ScrollContainer>
+      </SafeAreaWrapper>
+    );
+  }
+
+  return (
+    <SafeAreaWrapper>
+      <Popup
+        visible={showPopup}
+        message={popupMessage}
+        onClose={handleClosePopup}
+        type="success"
+      />
+      <ScrollContainer showsVerticalScrollIndicator={false}>
+        <Title>Edit Club</Title>
+
+        <TouchableOpacity onPress={handleImagePick} disabled={isSubmitting}>
+          <ImageWrapper>
+            {selectedImage ? (
+              <ClubImage source={{ uri: selectedImage }} />
+            ) : (
+              <ImagePlaceholder>
+                <Text style={{ color: "#ccc" }}>Tap to add image</Text>
+              </ImagePlaceholder>
+            )}
+            <PlusIconWrapper>
+              <AntDesign name="plus-circle" size={28} color="#2196f3" />
+            </PlusIconWrapper>
+          </ImageWrapper>
+        </TouchableOpacity>
+
+        <View>
+          <LabelContainer>
+            <Label>Description</Label>
+            {errors.clubDescription && (
+              <ErrorText>{errors.clubDescription.message}</ErrorText>
+            )}
+          </LabelContainer>
+          <Controller
+            control={control}
+            name="clubDescription"
+            rules={{
+              minLength: {
+                value: 10,
+                message: "Description must be at least 10 characters",
+              },
+            }}
+            render={({ field: { onChange, value, onBlur } }) => (
+              <TextAreaInput
+                value={value}
+                placeholder="Enter description"
+                placeholderTextColor="#ccc"
+                onChangeText={onChange}
+                onBlur={onBlur}
+                multiline
+                numberOfLines={4}
+                editable={!isSubmitting}
+              />
+            )}
+          />
+        </View>
+
+        <ButtonContainer>
+          <CancelButton
+            onPress={() => navigation.goBack()}
+            disabled={isSubmitting}
+          >
+            <CancelText>Cancel</CancelText>
+          </CancelButton>
+          <CreateButton
+            onPress={handleSubmit(onSubmit)}
+            disabled={!hasChanges || isSubmitting}
+            style={{ opacity: !hasChanges || isSubmitting ? 0.5 : 1 }}
+          >
+            <CreateText>{isSubmitting ? "Updating..." : "Update"}</CreateText>
+          </CreateButton>
+        </ButtonContainer>
+      </ScrollContainer>
+    </SafeAreaWrapper>
+  );
+};
+
+export default EditClub;
+
+// --- Styled Components (Object Style) ---
+const SafeAreaWrapper = styled(SafeAreaView)({
+  flex: 1,
+  backgroundColor: "rgb(3, 16, 31)",
+});
+
+const ScrollContainer = styled.ScrollView({
+  padding: 20,
+});
+
+const Title = styled.Text({
+  fontSize: 20,
+  color: "#fff",
+  fontWeight: "bold",
+  marginBottom: 20,
+  textAlign: "center",
+});
+
+const LabelContainer = styled.View({
+  marginBottom: 4,
+});
+
+const Label = styled.Text({
+  color: "#ccc",
+  fontSize: 12,
+  marginLeft: 4,
+});
+
+const ErrorText = styled.Text({
+  color: "red",
+  fontSize: 12,
+});
+
+const TextAreaInput = styled.TextInput({
+  height: 100,
+  backgroundColor: "rgba(255, 255, 255, 0.2)",
+  color: "white",
+  paddingLeft: 12,
+  borderRadius: 6,
+  marginBottom: 16,
+  textAlignVertical: "top",
+});
+
+const ImageWrapper = styled.View({
+  position: "relative",
+  width: "100%",
+  height: 200,
+  marginBottom: 20,
+});
+
+const ClubImage = styled.Image({
+  width: "100%",
+  height: "100%",
+  borderRadius: 8,
+});
+
+const ImagePlaceholder = styled.View({
+  width: "100%",
+  height: "100%",
+  backgroundColor: "#001e3c",
+  justifyContent: "center",
+  alignItems: "center",
+  borderRadius: 8,
+  borderWidth: 2,
+  borderStyle: "dashed",
+  borderColor: "#555",
+});
+
+const PlusIconWrapper = styled.View({
+  position: "absolute",
+  bottom: 10,
+  right: 10,
+  borderRadius: 16,
+});
+
+const ButtonContainer = styled.View({
+  flexDirection: "row",
+  justifyContent: "space-between",
+  marginTop: 20,
+});
+
+const CancelButton = styled.TouchableOpacity({
+  width: "45%",
+  padding: 12,
+  backgroundColor: "#9e9e9e",
+  borderRadius: 6,
+});
+
+const CancelText = styled.Text({
+  textAlign: "center",
+  color: "white",
+  fontSize: 16,
+});
+
+const CreateButton = styled.TouchableOpacity({
+  width: "45%",
+  padding: 12,
+  backgroundColor: "#2196f3",
+  borderRadius: 6,
+});
+
+const CreateText = styled.Text({
+  textAlign: "center",
+  color: "white",
+  fontSize: 16,
+});

--- a/screens/Home/Clubs/tabs/ClubSummary.tsx
+++ b/screens/Home/Clubs/tabs/ClubSummary.tsx
@@ -1,0 +1,184 @@
+import React, { useContext, useEffect, useState } from "react";
+import { ActivityIndicator } from "react-native";
+import styled from "styled-components/native";
+// ParticipantCarousel is shared with CompetitionSummary — it renders the member
+// avatars row plus Owner/Admin labels, so clubs get the same treatment.
+import ParticipantCarousel from "../../../../components/Summary/ParticipantCarousel";
+import { LeagueContext } from "../../../../context/LeagueContext";
+import {
+  getClubSummaryStats,
+  ClubSummaryStats,
+} from "../../../../helpers/clubPlayerStats";
+import type { Club, Player } from "@shared/types";
+
+interface ClubSummaryProps {
+  clubId: string;
+  club: Club | null;
+}
+
+/** createdAt may arrive as a Firestore Timestamp, a Date, or a serialized value. */
+const formatFounded = (createdAt: unknown): string => {
+  if (!createdAt) return "—";
+  const raw = createdAt as { toDate?: () => Date; seconds?: number };
+  let date: Date;
+  if (typeof raw.toDate === "function") date = raw.toDate();
+  else if (typeof raw.seconds === "number") date = new Date(raw.seconds * 1000);
+  else date = new Date(createdAt as string | number | Date);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+  });
+};
+
+const ClubSummary: React.FC<ClubSummaryProps> = ({ clubId, club }) => {
+  const { fetchClubParticipants } = useContext(LeagueContext);
+
+  const [participants, setParticipants] = useState<Player[]>([]);
+  const [stats, setStats] = useState<ClubSummaryStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const [members, summary] = await Promise.all([
+          fetchClubParticipants(clubId),
+          getClubSummaryStats({ clubId }),
+        ]);
+        if (cancelled) return;
+        setParticipants(members);
+        setStats(summary);
+      } catch (error) {
+        console.error("Club summary load error:", error);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [clubId, fetchClubParticipants]);
+
+  if (loading) {
+    return (
+      <LoadingContainer>
+        <ActivityIndicator size="large" color="#00A2FF" />
+      </LoadingContainer>
+    );
+  }
+
+  const topPlayer = stats?.topPlayer?.username ?? "—";
+  const topTeam = stats?.topTeam?.team?.length
+    ? stats.topTeam.team.join(" & ")
+    : "—";
+  const totalGames = stats?.totalGamesPlayed ?? 0;
+  const founded = formatFounded(club?.createdAt);
+
+  return (
+    <Container showsVerticalScrollIndicator={false}>
+      {/* Headline club-level metrics */}
+      <MetricsGrid>
+        <MetricCard>
+          <MetricLabel>Founded</MetricLabel>
+          <MetricValue>{founded}</MetricValue>
+        </MetricCard>
+        <MetricCard>
+          <MetricLabel>Games Played</MetricLabel>
+          <MetricValue>{totalGames}</MetricValue>
+        </MetricCard>
+        <MetricCard>
+          <MetricLabel>Top Player</MetricLabel>
+          <MetricValue numberOfLines={1}>{topPlayer}</MetricValue>
+        </MetricCard>
+        <MetricCard>
+          <MetricLabel>Top Team</MetricLabel>
+          <MetricValue numberOfLines={1}>{topTeam}</MetricValue>
+        </MetricCard>
+      </MetricsGrid>
+
+      {/* Members */}
+      <ParticipantCarousel
+        participants={participants}
+        admins={club?.clubAdmins ?? []}
+        owner={club?.clubOwner ?? {}}
+      />
+
+      {/* Description */}
+      <Section>
+        <SectionTitle>Description</SectionTitle>
+        {club?.clubDescription ? (
+          <DescriptionText>{club.clubDescription}</DescriptionText>
+        ) : (
+          <DisabledText>No description available</DisabledText>
+        )}
+      </Section>
+    </Container>
+  );
+};
+
+export default ClubSummary;
+
+// --- Styled ---
+const Container = styled.ScrollView({
+  flex: 1,
+  padding: 20,
+});
+
+const LoadingContainer = styled.View({
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+  paddingVertical: 40,
+});
+
+const MetricsGrid = styled.View({
+  flexDirection: "row",
+  flexWrap: "wrap",
+  justifyContent: "space-between",
+  marginBottom: 20,
+});
+
+const MetricCard = styled.View({
+  width: "48%",
+  backgroundColor: "rgba(255, 255, 255, 0.06)",
+  borderRadius: 12,
+  padding: 16,
+  marginBottom: 12,
+});
+
+const MetricLabel = styled.Text({
+  color: "#8b95a5",
+  fontSize: 12,
+  marginBottom: 6,
+});
+
+const MetricValue = styled.Text({
+  color: "white",
+  fontSize: 18,
+  fontWeight: "bold",
+});
+
+const Section = styled.View({
+  marginBottom: 20,
+});
+
+const SectionTitle = styled.Text({
+  fontSize: 16,
+  fontWeight: "bold",
+  color: "#ffffff",
+  marginBottom: 10,
+});
+
+const DescriptionText = styled.Text({
+  color: "#cccccc",
+  fontSize: 14,
+  lineHeight: 20,
+});
+
+const DisabledText = styled.Text({
+  color: "#888",
+  fontSize: 14,
+});

--- a/screens/Home/Settings/ClubAssignAdmin.tsx
+++ b/screens/Home/Settings/ClubAssignAdmin.tsx
@@ -1,0 +1,215 @@
+import React, { useEffect, useState, useContext } from "react";
+import { FlatList, ActivityIndicator } from "react-native";
+import styled from "styled-components/native";
+import {
+  useNavigation,
+  useRoute,
+  NavigationProp,
+  ParamListBase,
+} from "@react-navigation/native";
+import { LeagueContext } from "../../../context/LeagueContext";
+import { UserContext } from "../../../context/UserContext";
+import Tag from "../../../components/Tag";
+import { Club, CompetitionAdmins, Player } from "@shared/types";
+
+const ClubAssignAdmin = () => {
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+
+  const route = useRoute();
+  const { clubId } = route.params as { clubId: string };
+
+  const { currentUser } = useContext(UserContext);
+  const {
+    fetchClubById,
+    fetchClubParticipants,
+    assignClubAdmin,
+    revokeClubAdmin,
+  } = useContext(LeagueContext);
+
+  const [club, setClub] = useState<Club | null>(null);
+  const [participants, setParticipants] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchClub();
+  }, []);
+
+  const fetchClub = async () => {
+    setLoading(true);
+    try {
+      const [fetchedClub, fetchedParticipants] = await Promise.all([
+        fetchClubById(clubId),
+        fetchClubParticipants(clubId),
+      ]);
+      setClub(fetchedClub);
+      setParticipants(fetchedParticipants);
+    } catch (error) {
+      console.error("Failed to fetch club:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAssign = async (user: Player) => {
+    if (!user.userId) return;
+    await assignClubAdmin({
+      clubId,
+      user: { userId: user.userId, username: user.username ?? "" },
+    });
+    fetchClub();
+  };
+
+  const handleRevoke = async (userId: string) => {
+    await revokeClubAdmin({ clubId, userId });
+    fetchClub();
+  };
+
+  const goToProfile = (userId: string) => {
+    navigation.navigate("UserProfile", { userId });
+  };
+
+  const isAdmin = (userId: string | undefined) =>
+    userId
+      ? club?.clubAdmins?.some(
+          (admin: CompetitionAdmins) => admin.userId === userId,
+        )
+      : false;
+
+  const renderItem = ({ item }: { item: Player }) => {
+    const isUserAdmin = isAdmin(item.userId);
+    const isOwner = item.userId === club?.clubOwner?.userId;
+    const isCurrentUser = item.userId === currentUser?.userId;
+
+    const canAssign = !isUserAdmin && !isCurrentUser && !isOwner;
+    const canRevoke =
+      isUserAdmin &&
+      currentUser?.userId === club?.clubOwner?.userId &&
+      !isOwner;
+
+    return (
+      <PlayerRow onPress={() => item.userId && goToProfile(item.userId)}>
+        <Player_>
+          <Username>{item.username}</Username>
+          {isUserAdmin && (
+            <Tag
+              name={"Admin"}
+              color="rgb(3, 16, 31)"
+              iconColor="#00A2FF"
+              iconSize={15}
+              icon={"checkmark-circle-outline"}
+              iconPosition={"right"}
+              bold
+            />
+          )}
+        </Player_>
+
+        <Action>
+          {canAssign && (
+            <ActionButton onPress={() => handleAssign(item)}>
+              <ButtonText>Assign</ButtonText>
+            </ActionButton>
+          )}
+          {canRevoke && (
+            <RevokeButton onPress={() => handleRevoke(item.userId!)}>
+              <ButtonText>Revoke</ButtonText>
+            </RevokeButton>
+          )}
+        </Action>
+      </PlayerRow>
+    );
+  };
+
+  if (loading || !club) {
+    return (
+      <LoadingContainer>
+        <ActivityIndicator size="large" color="#00A2FF" />
+      </LoadingContainer>
+    );
+  }
+
+  return (
+    <Container>
+      <Title>Assign Club Admins</Title>
+      <FlatList
+        data={participants}
+        keyExtractor={(item, index) => item.userId ?? index.toString()}
+        renderItem={renderItem}
+        ItemSeparatorComponent={() => <Separator />}
+      />
+    </Container>
+  );
+};
+
+export default ClubAssignAdmin;
+
+// --- Styled ---
+const Container = styled.View({
+  flex: 1,
+  backgroundColor: "rgb(3, 16, 31)",
+  padding: 20,
+});
+
+const Title = styled.Text({
+  color: "white",
+  fontSize: 20,
+  fontWeight: "bold",
+  marginBottom: 20,
+});
+
+const PlayerRow = styled.TouchableOpacity({
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+  backgroundColor: "rgba(255,255,255,0.05)",
+  padding: 12,
+  borderRadius: 8,
+});
+
+const Player_ = styled.View({
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 8,
+});
+
+const Action = styled.View({
+  flexDirection: "row",
+  gap: 10,
+});
+
+const Username = styled.Text({
+  color: "white",
+  fontSize: 16,
+});
+
+const ActionButton = styled.TouchableOpacity({
+  backgroundColor: "#00A2FF",
+  paddingVertical: 6,
+  paddingHorizontal: 14,
+  borderRadius: 6,
+  width: 80,
+});
+
+const RevokeButton = styled.TouchableOpacity({
+  backgroundColor: "#e53935",
+  paddingVertical: 6,
+  paddingHorizontal: 14,
+  borderRadius: 6,
+  width: 80,
+});
+
+const ButtonText = styled.Text({
+  color: "white",
+  fontSize: 14,
+  fontWeight: "bold",
+});
+
+const LoadingContainer = styled.View({
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+  backgroundColor: "rgb(3, 16, 31)",
+});
+
+const Separator = styled.View({
+  height: 10,
+});

--- a/screens/Home/Settings/ClubRemoveMembers.tsx
+++ b/screens/Home/Settings/ClubRemoveMembers.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useState, useContext } from "react";
+import { FlatList, ActivityIndicator } from "react-native";
+import styled from "styled-components/native";
+import {
+  useNavigation,
+  useRoute,
+  NavigationProp,
+  ParamListBase,
+} from "@react-navigation/native";
+import { LeagueContext } from "../../../context/LeagueContext";
+import { UserContext } from "../../../context/UserContext";
+import Tag from "../../../components/Tag";
+import RemovePlayerModal from "../../../components/Modals/RemovePlayerModal";
+import { Club, CompetitionAdmins, Player } from "@shared/types";
+
+const ClubRemoveMembers = () => {
+  const navigation = useNavigation<NavigationProp<ParamListBase>>();
+  const route = useRoute();
+
+  const { clubId } = route.params as { clubId: string };
+
+  const { fetchClubById, fetchClubParticipants, removeClubMember } =
+    useContext(LeagueContext);
+  const { currentUser } = useContext(UserContext);
+
+  const [club, setClub] = useState<Club | null>(null);
+  const [participants, setParticipants] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedMember, setSelectedMember] = useState<Player | null>(null);
+
+  const fetchClub = async () => {
+    setLoading(true);
+    try {
+      const [fetchedClub, fetchedParticipants] = await Promise.all([
+        fetchClubById(clubId),
+        fetchClubParticipants(clubId),
+      ]);
+      setClub(fetchedClub);
+      setParticipants(fetchedParticipants);
+    } catch (error) {
+      console.error("Failed to fetch club:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchClub();
+  }, []);
+
+  const handleRemove = (member: Player) => {
+    setSelectedMember(member);
+    setModalVisible(true);
+  };
+
+  const goToProfile = (userId: string) => {
+    navigation.navigate("UserProfile", { userId });
+  };
+
+  const sortOwnerByFirst = (a: Player, b: Player) => {
+    const isOwnerA = a.userId === club?.clubOwner?.userId;
+    const isOwnerB = b.userId === club?.clubOwner?.userId;
+    if (isOwnerA && !isOwnerB) return -1;
+    if (!isOwnerA && isOwnerB) return 1;
+    return 0;
+  };
+
+  const sortedParticipants = [...participants].sort(sortOwnerByFirst);
+
+  const renderItem = ({ item }: { item: Player }) => {
+    const isOwner = item.userId === club?.clubOwner?.userId;
+    const isAdmin = club?.clubAdmins?.some(
+      (admin: CompetitionAdmins) => admin.userId === item.userId,
+    );
+    const isSelf = item.userId === currentUser?.userId;
+    const canRemove =
+      currentUser?.userId === club?.clubOwner?.userId && !isOwner && !isSelf;
+
+    return (
+      <PlayerRow onPress={() => item.userId && goToProfile(item.userId)}>
+        <Player_>
+          <Username>{item.username}</Username>
+          {isOwner && (
+            <>
+              <Tag
+                name={"Owner"}
+                color="rgb(3, 16, 31)"
+                iconColor="#FFD700"
+                iconSize={15}
+                icon={"star-outline"}
+                iconPosition={"right"}
+                bold
+              />
+              <Tag
+                name={"Admin"}
+                color="rgb(3, 16, 31)"
+                iconColor="#00A2FF"
+                iconSize={15}
+                icon={"checkmark-circle-outline"}
+                iconPosition={"right"}
+                bold
+              />
+            </>
+          )}
+          {isAdmin && !isOwner && (
+            <Tag
+              name={"Admin"}
+              color="rgb(3, 16, 31)"
+              iconColor="#00A2FF"
+              iconSize={15}
+              icon={"checkmark-circle-outline"}
+              iconPosition={"right"}
+              bold
+            />
+          )}
+        </Player_>
+
+        {canRemove && (
+          <RemoveButton onPress={() => handleRemove(item)}>
+            <ButtonText>Remove</ButtonText>
+          </RemoveButton>
+        )}
+      </PlayerRow>
+    );
+  };
+
+  if (loading || !club) {
+    return (
+      <LoadingContainer>
+        <ActivityIndicator size="large" color="#00A2FF" />
+      </LoadingContainer>
+    );
+  }
+
+  return (
+    <Container>
+      <Title>Remove Members</Title>
+      <FlatList
+        data={sortedParticipants}
+        keyExtractor={(item, index) => item.userId ?? index.toString()}
+        renderItem={renderItem}
+        ItemSeparatorComponent={() => <Separator />}
+      />
+
+      <RemovePlayerModal
+        visible={modalVisible}
+        playerName={selectedMember?.username}
+        entityLabel="club"
+        onClose={() => {
+          setModalVisible(false);
+          setSelectedMember(null);
+        }}
+        onConfirm={async (reason: string) => {
+          await removeClubMember({
+            clubId,
+            userId: selectedMember?.userId ?? "",
+            reason,
+          });
+
+          await fetchClub();
+          setModalVisible(false);
+          setSelectedMember(null);
+        }}
+      />
+    </Container>
+  );
+};
+
+export default ClubRemoveMembers;
+
+// Styled
+const Container = styled.View({
+  flex: 1,
+  backgroundColor: "rgb(3, 16, 31)",
+  padding: 20,
+});
+
+const Title = styled.Text({
+  color: "white",
+  fontSize: 20,
+  fontWeight: "bold",
+  marginBottom: 20,
+});
+
+const PlayerRow = styled.TouchableOpacity({
+  flexDirection: "row",
+  justifyContent: "space-between",
+  alignItems: "center",
+  backgroundColor: "rgba(255,255,255,0.05)",
+  padding: 12,
+  borderRadius: 8,
+});
+
+const Player_ = styled.View({
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 8,
+});
+
+const Username = styled.Text({
+  color: "white",
+  fontSize: 16,
+});
+
+const RemoveButton = styled.TouchableOpacity({
+  backgroundColor: "#e53935",
+  paddingVertical: 6,
+  paddingHorizontal: 14,
+  borderRadius: 6,
+  width: 80,
+});
+
+const ButtonText = styled.Text({
+  color: "white",
+  fontSize: 13,
+  fontWeight: "bold",
+});
+
+const LoadingContainer = styled.View({
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+  backgroundColor: "rgb(3, 16, 31)",
+});
+
+const Separator = styled.View({
+  height: 10,
+});

--- a/shared/types/club.ts
+++ b/shared/types/club.ts
@@ -47,6 +47,7 @@ export type ClubParticipantDocument = Player;
 
 /** Kinds of activity surfaced in the club feed. */
 export type ClubFeedType =
+  | "club_created"
   | "player_joined"
   | "competition_won"
   | "competition_created";


### PR DESCRIPTION
## Overview
Completes the club management feature: wires up all Club Settings actions, adds a proper delete cleanup, introduces a **Club Summary** tab, and fixes two bugs found in testing.

## Club Settings (earlier commits on this branch)
- **Edit Club / Assign Admin / Remove Members / Delete Club** now fully implemented, mirroring `LeagueSettings`/`TournamentSettings` but against the club data model (`clubOwner`/`clubAdmins` on the doc, members in the `participants` subcollection).
- New context helpers: `updateClub`, `fetchClubParticipants`, `assignClubAdmin`, `revokeClubAdmin`, `removeClubMember`, `deleteClub`.
- New screens: `EditClub`, `ClubAssignAdmin`, `ClubRemoveMembers`, registered across all navigator stacks.
- **Delete** now removes the club's `participants` / `feed` / `chat` subcollections (batched) before the root doc, so nothing is orphaned. Competitions are top-level (linked by `clubId`) and intentionally left intact; the existing "Club not found." screen covers the dead link.

## New: Club Summary tab
`screens/Home/Clubs/tabs/ClubSummary.tsx` — a trimmed reflection of `CompetitionSummary`:
- Renders **club description** + **members carousel** (reuses `ParticipantCarousel`).
- Headline metrics: **Founded**, **Games Played**, **Top Player**, **Top Team** — aggregated across the club's leagues + tournaments via a new `getClubSummaryStats` helper (reuses the existing club player accumulation).
- Drops Top Contenders / Prize Winners / Prize Distribution / dates / full address per spec.
- Added as the club's landing tab.

## Bug fixes
- **Stale "Request Pending" button.** After the owner accepted a join request, the requester's button stayed on "Request Pending". `Club.tsx` only fetched the participants subcollection on first mount, so membership never refreshed while the screen stayed in the stack. It now re-fetches participants on every focus and re-derives the role.
- **Clubs missing from profile Activity → Clubs.** That list was derived only from the competitions a user is in, so a club joined/owned with no competitions never appeared. Added `getMemberClubIds` (a collection-group query over `participants`) and merged it into `ProfileActivity`.

## Firestore index
The new collection-group query needs a `COLLECTION_GROUP` single-field index on `participants.userId`, declared in `firestore.indexes.json`. The query degrades gracefully to `[]` (falls back to competition-derived clubs) if the index isn't deployed yet, so it won't error pre-deploy.

## Validation
- TypeScript: no new errors in touched files.
- ESLint: clean on touched files.
- Not runtime-tested in this environment; manual QA recommended (esp. the join-button flow and the Activity → Clubs tab once the index is deployed).

## Notes / follow-ups
- AC1 (admins removing members) and AC7 (instant self-join for members) remain intentionally deferred.
- Club feed accuracy is a separate known issue — plan to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Uk43UDRnzxpZGQzBvEPp2)_